### PR TITLE
add:HOME画面の作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,9 +23,12 @@ gem "jbuilder"
 # gem "bcrypt", "~> 3.1.7"
 
 # 追加分
-gem "devise"
+gem "devise" # 認証系
 gem "whenever", require: false
 gem "image_processing", "~> 1.2" # 画像のリサイズ
+gem "ransack", "4.3.0" # 検索
+gem "kaminari", "1.2.2" # ページネーション用
+gem "bootstrap5-kaminari-views"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,9 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
+    bootstrap5-kaminari-views (0.0.1)
+      kaminari (>= 0.13)
+      rails (>= 3.1)
     brakeman (7.1.0)
       racc
     builder (3.3.0)
@@ -165,6 +168,18 @@ GEM
       sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -282,6 +297,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.0)
+    ransack (4.3.0)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
@@ -406,6 +425,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  bootstrap5-kaminari-views
   brakeman
   capybara
   cssbundling-rails
@@ -416,10 +436,12 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   kamal
+  kaminari (= 1.2.2)
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2, >= 8.0.2.1)
+  ransack (= 4.3.0)
   rubocop-rails-omakase
   selenium-webdriver
   solid_cable

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,3 +1,42 @@
 class HomeController < ApplicationController
-  def index; end
+  def index
+    @categories = Category.pluck(:name)
+    @shops = Shop.pluck(:name)
+
+    @q = current_user.price_records.ransack(params[:q])
+
+    @price_records = @q.result.includes(:product, :shop).order(created_at: :desc).limit(10)
+
+    latest_record = current_user.price_records.order(created_at: :desc).first
+
+    if latest_record.present?
+      set_summary(latest_record.product)
+    else
+      @selected_product = nil
+      @price_records = []
+    end
+  end
+
+  def show_summary
+    product = Product.find(params[:id])
+    set_summary(product)
+
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+
+  private
+
+  def set_summary(product)
+    histories = product.price_records.order(created_at: :desc)
+
+    @selected_product = product
+    @min_price = histories.minimum(:price)
+    @max_price = histories.maximum(:price)
+    @average_price = histories.average(:price)&.round
+    latest = histories.first
+    @last_price = latest&.price
+    @last_purchased_at = latest&.created_at
+  end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import SummaryController from "./summary_controller"
+application.register("summary", SummaryController)

--- a/app/javascript/controllers/summary_controller.js
+++ b/app/javascript/controllers/summary_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "@hotwired/stimulus"
+import * as Turbo from "@hotwired/turbo"
+
+export default class extends Controller {
+  async fetch(event) {
+    const productId = event.currentTarget.dataset.summaryProductId
+
+    try {
+      const response = await fetch(`/home/summary/${productId}`, {
+        headers: { "Accept": "text/vnd.turbo-stream.html" }
+      })
+      if (!response.ok) throw new Error("Failed to fetch summary")
+
+      const turboStream = await response.text()
+      Turbo.renderStreamMessage(turboStream)
+
+    } catch (error) {
+      console.error("Error fetching summary:", error)
+    }
+  }
+}

--- a/app/views/home/_summary.html.erb
+++ b/app/views/home/_summary.html.erb
@@ -1,0 +1,13 @@
+<div id= "summary" class="price-summary card p-3 mb-4">
+    <h2 class="h5 mb-3">価格サマリー</h2>
+    <% if @min_price.nil? && @max_price.nil? && @average_price.nil? && @last_price.nil? %>
+      <p class="text-gray-500">まだ価格の登録がありません</p>
+    <% else %>
+      <div class="d-flex justify-content-between">
+        <div>最安値: <span class="text-danger">¥<%= @min_price || '未登録' %></span></div>
+        <div>最高値: ¥<%= @max_price || '未登録' %></div>
+      </div>
+      <div class="mt-2">平均価格: ¥<%= @average_price || '未登録' %></div>
+      <div class="mt-2">前回購入: ¥<%= @last_price || '未登録' %>（<%= @last_purchased_at&.strftime('%Y/%m/%d') || '----/--/--' %>）</div>
+    <% end %>
+  </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,9 +1,69 @@
-<h1>Welcome to Okaimonote!</h1>
-<p>仮のHOME画面は表示されかな？</p>
-<% if user_signed_in? %>
-  <p>こんにちは、<%= current_user.email %> さん！</p>
-  <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
-<% else %>
-  <%= link_to "ログイン", new_user_session_path %> |
-  <%= link_to "新規登録", new_user_registration_path %>
-<% end %>
+<div class= "container mx-auto px-4 py-6">
+  <h1 class= "text-2xl font-bold mb-4">HOME</h1>
+
+  <!-- 検索機能(非表示) -->
+  <div data-controller="toggle">
+    <button data-action="click->toggle#toggle" class="bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded mb-4">
+      絞り込み検索
+    </button>
+
+    <div data-toggle-target="content" class="hidden mb-4">
+      <%= search_form_for @q, url: home_path, method: :get, class: "bg-white p-4 rounded shadow" do |f| %>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <%= f.label :product_name_cont, "商品名" %>
+            <%= f.search_field :product_name_cont, class: "form-control w-full" %>
+          </div>
+
+          <div>
+            <%= f.label :category_name_eq, "カテゴリー" %>
+            <%= f.select :category_name_eq, Category.pluck(:name), { include_blank: "選択してください" }, class: "form-control w-full" %>
+          </div>
+
+          <div>
+            <%= f.label :shop_name_eq, "店舗" %>
+            <%= f.select :shop_name_eq, Shop.pluck(:name), { include_blank: "選択してください" }, class: "form-control w-full" %>
+          </div>
+
+        </div>
+
+        <div class="mt-4">
+          <%= f.submit "検索", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <!-- 価格サマリー -->
+  <%= render "summary" %>
+
+  <!-- 価格登録履歴 -->
+  <h2 class="h5 mb-3">価格登録履歴（新着順）</h2>
+
+  <% if @price_records.blank? %>
+    <p class="text-muted">まだ価格の登録がありません</p>
+  <% else %>
+    <% @price_records.each do |record| %>
+      <div class="card mb-3 shadow-sm cursor-pointer"
+           data-action="click->summary#fetch"
+           data-summary-product-id="<%= record.product.id %>">
+        <div class="card-body">
+          <h5 class="card-title font-bold mb-2"><%= record.product.name %></h5>
+
+          <p class="fs-5 mb-1 text-primary">¥<%= number_with_delimiter(record.price) %></p>
+
+          <p class="text-muted small mb-2">
+            店舗：<%= record.shop&.name || "未登録" %> ／ 登録日：<%= l(record.created_at, format: :short) %>
+          </p>
+
+          <% if record.memo.present? %>
+            <details>
+              <summary class="text-muted small">▼ メモを見る</summary>
+              <p class="mt-1 small text-secondary"><%= simple_format(record.memo) %></p>
+            </details>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/home/show_summary.turbo_stream.erb
+++ b/app/views/home/show_summary.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "summary" do %>
+  <%= render "summary" %>
+<% end %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -6,7 +6,7 @@
     <div class="buttons">
       <%= link_to "新規登録", new_user_registration_path, class: "btn btn-orange" %>
       <%= link_to "ログイン", new_user_session_path, class: "btn btn-white" %>
-      <%= link_to "ゲスト", guest_sign_in_path, method: :post, class: "btn btn-gray" %>
+      <%= button_to "ゲスト", guest_sign_in_path, method: :post, class: "btn btn-gray" %>
     </div>
   </div>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -20,3 +20,6 @@ ja:
   errors:
     messages:
       not_saved: "%{resource}にエラーが発生し、登録できませんでした。"
+  time:
+    formats:
+      short: "%Y/%m/%d"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,9 @@ Rails.application.routes.draw do
     post "users/guest_sign_in", to: "users/sessions#guest_sign_in", as: :guest_sign_in
   end
 
-  get "home", to:  "home#index", as: :home
+  get "home", to: "home#index", as: :home
+  get "home/summary", to: "home#summary", as: :home_summary
+
   resources :products
   resources :shops
   resources :records


### PR DESCRIPTION
【概要】
HOME画面のview設定
・検索画面のトグル化
・価格サマリー設定
・登録履歴を表示(新着10件)
controllerの設定
・基本的な表示
・履歴のカードをタッチで商品のサマリーを更新