### PR TITLE
feat: Rails JSON API エンドポイントを追加する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "ransack", "4.3.0" # 検索
 gem "kaminari", "1.2.2" # ページネーション用
 gem "bootstrap5-kaminari-views"
 gem "rack-attack" # 不正アクセス対策
+gem "rack-cors"   # Next.jsフロントエンドからのCORSリクエストを許可
 gem "addressable" # URL生成を安定化（OGPで絶対URLを扱うため）
 gem "omniauth-google-oauth2" # google認証用
 gem "omniauth-rails_csrf_protection" # 認証系用

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,6 +337,9 @@ GEM
     rack (3.2.1)
     rack-attack (6.8.0)
       rack (>= 1.0, < 4)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-protection (4.2.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
@@ -562,6 +565,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rack-attack
+  rack-cors
   rails (~> 8.0.2, >= 8.0.2.1)
   ransack (= 4.3.0)
   rqrcode

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -1,0 +1,21 @@
+# 認証情報APIコントローラー
+# Next.jsフロントエンドが起動時に現在のログインユーザー情報を取得するために使用する
+module Api
+  module V1
+    class AuthController < BaseController
+      # GET /api/v1/me
+      # 現在のログインユーザー情報をJSONで返す
+      def me
+        render json: {
+          id: current_user.id,
+          email: current_user.email,
+          nickname: current_user.nickname,
+          role: current_user.role,
+          family_role: current_user.family_role,
+          prefecture: current_user.prefecture,
+          avatar_url: current_user.avatar.attached? ? url_for(current_user.avatar) : nil
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,21 @@
+# API v1 コントローラーの基底クラス
+# 全APIエンドポイントで共通の認証・レスポンス処理を担当する
+module Api
+  module V1
+    class BaseController < ApplicationController
+      # APIはCSRFトークン不要（Cookieセッション認証はOriginで保護される）
+      skip_before_action :verify_authenticity_token
+
+      before_action :authenticate_user!
+
+      private
+
+      # 未認証時はHTMLリダイレクトではなく401 JSONを返す
+      def authenticate_user!
+        unless current_user
+          render json: { error: "ログインが必要です" }, status: :unauthorized
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module V1
+    class ProductsController < BaseController
+      # GET /api/v1/products
+      def index
+        owner = current_user.family_owner
+        products = owner.products.includes(:category).order(created_at: :desc)
+
+        render json: products.map { |p| product_json(p) }
+      end
+
+      private
+
+      def product_json(product)
+        {
+          id: product.id,
+          public_id: product.public_id,
+          name: product.name,
+          memo: product.memo,
+          category: product.category ? { id: product.category.id, name: product.category.name } : nil
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/shopping_list_controller.rb
+++ b/app/controllers/api/v1/shopping_list_controller.rb
@@ -1,0 +1,76 @@
+module Api
+  module V1
+    class ShoppingListController < BaseController
+      before_action :set_shopping_list
+      before_action :set_item, only: [ :update_item, :destroy_item ]
+
+      # GET /api/v1/shopping_list
+      def show
+        render json: shopping_list_json(@shopping_list)
+      end
+
+      # POST /api/v1/shopping_list/items
+      def create_item
+        item = @shopping_list.shopping_items.new(item_params)
+        if item.save
+          render json: item_json(item), status: :created
+        else
+          render json: { errors: item.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # PATCH /api/v1/shopping_list/items/:id
+      def update_item
+        if @item.update(item_params)
+          render json: item_json(@item)
+        else
+          render json: { errors: @item.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # DELETE /api/v1/shopping_list/items/:id
+      def destroy_item
+        @item.destroy
+        head :no_content
+      end
+
+      # DELETE /api/v1/shopping_list/items/purchased
+      def delete_purchased
+        @shopping_list.shopping_items.where(purchased: true).destroy_all
+        head :no_content
+      end
+
+      private
+
+      def set_shopping_list
+        @shopping_list = current_user.active_shopping_list
+      end
+
+      def set_item
+        @item = @shopping_list.shopping_items.find(params[:id])
+      end
+
+      def item_params
+        params.require(:shopping_item).permit(:name, :memo, :purchased)
+      end
+
+      def shopping_list_json(list)
+        {
+          id: list.id,
+          public_id: list.public_id,
+          name: list.name,
+          items: list.shopping_items.order(created_at: :desc).map { |item| item_json(item) }
+        }
+      end
+
+      def item_json(item)
+        {
+          id: item.id,
+          name: item.name,
+          memo: item.memo,
+          purchased: item.purchased
+        }
+      end
+    end
+  end
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,20 @@
+# Next.jsフロントエンドからのAPIリクエストを許可するCORS設定
+# credentials: true を指定することでDeviseのセッションCookieを送受信できる
+
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    # 開発環境: Next.js dev server
+    # 本番環境: 同一ドメイン（nginx でルーティングするため実質不要だが念のため設定）
+    origins(
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      ENV.fetch("FRONTEND_URL", "https://www.okaimonote.com")
+    )
+
+    resource "/api/*",
+      headers: :any,
+      methods: [ :get, :post, :put, :patch, :delete, :options, :head ],
+      credentials: true,
+      expose: [ "X-CSRF-Token" ]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,24 @@ Rails.application.routes.draw do
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
+  # Next.jsフロントエンド向けJSON API
+  namespace :api do
+    namespace :v1 do
+      get "me", to: "auth#me"
+
+      # ショッピングリスト
+      # ショッピングリスト (singular resource: /api/v1/shopping_list)
+      get    "shopping_list",                  to: "shopping_list#show"
+      post   "shopping_list/items",            to: "shopping_list#create_item"
+      patch  "shopping_list/items/:id",        to: "shopping_list#update_item"
+      delete "shopping_list/items/purchased",  to: "shopping_list#delete_purchased"
+      delete "shopping_list/items/:id",        to: "shopping_list#destroy_item"
+
+      # 商品
+      resources :products, only: [ :index ]
+    end
+  end
+
   get "up" => "rails/health#show", as: :rails_health_check
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,11 +37,17 @@ end
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 RSpec.configure do |config|
+  # Devise mappings are populated when routes are drawn.
+  # Force route drawing before any spec runs so sign_in helpers work correctly.
+  config.before(:suite) do
+    Rails.application.routes.recognize_path("/") rescue nil
+  end
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [
     Rails.root.join('spec/fixtures')
   ]
   config.include Devise::Test::IntegrationHelpers, type: :system
+  config.include Devise::Test::IntegrationHelpers, type: :request
   config.include FactoryBot::Syntax::Methods
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/requests/api/v1/auth_spec.rb
+++ b/spec/requests/api/v1/auth_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth", type: :request do
+  describe "GET /api/v1/me" do
+    context "認証済みユーザーの場合" do
+      let(:user) { create(:user) }
+
+      before { sign_in(user, scope: :user) }
+
+      it "200とユーザー情報をJSONで返す" do
+        get "/api/v1/me"
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json["id"]).to eq(user.id)
+        expect(json["email"]).to eq(user.email)
+        expect(json["nickname"]).to eq(user.nickname)
+        expect(json["role"]).to eq(user.role)
+        expect(json["family_role"]).to eq(user.family_role)
+      end
+
+      it "パスワードやトークンなど機密情報を含まない" do
+        get "/api/v1/me"
+
+        json = response.parsed_body
+        expect(json.keys).not_to include("encrypted_password", "reset_password_token")
+      end
+    end
+
+    context "未認証の場合" do
+      it "401を返す" do
+        get "/api/v1/me"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/products_spec.rb
+++ b/spec/requests/api/v1/products_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Products", type: :request do
+  describe "GET /api/v1/products" do
+    context "認証済みユーザーの場合" do
+      let(:user) { create(:user) }
+      let!(:product) { create(:product, user: user) }
+
+      before { sign_in(user, scope: :user) }
+
+      it "200と商品一覧をJSONで返す" do
+        get "/api/v1/products"
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json).to be_an(Array)
+        expect(json.first["id"]).to be_present
+        expect(json.first["name"]).to eq(product.name)
+      end
+
+      it "他ユーザーの商品は含まれない" do
+        other_user = create(:user)
+        create(:product, user: other_user, name: "他人の商品")
+
+        get "/api/v1/products"
+
+        json = response.parsed_body
+        names = json.map { |p| p["name"] }
+        expect(names).not_to include("他人の商品")
+      end
+    end
+
+    context "未認証の場合" do
+      it "401を返す" do
+        get "/api/v1/products"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/shopping_list_spec.rb
+++ b/spec/requests/api/v1/shopping_list_spec.rb
@@ -1,0 +1,120 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::ShoppingList", type: :request do
+  describe "GET /api/v1/shopping_list" do
+    context "認証済みユーザーの場合" do
+      let(:user) { create(:user) }
+      let!(:shopping_list) { create(:shopping_list, user: user) }
+
+      before { sign_in(user, scope: :user) }
+
+      it "200とショッピングリスト情報をJSONで返す" do
+        get "/api/v1/shopping_list"
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json["id"]).to be_present
+        expect(json["name"]).to eq(shopping_list.name)
+        expect(json["items"]).to be_an(Array)
+      end
+
+      it "アイテムがある場合はitemsに含まれる" do
+        item = create(:shopping_item, shopping_list: shopping_list)
+
+        get "/api/v1/shopping_list"
+
+        json = response.parsed_body
+        expect(json["items"].length).to eq(1)
+        expect(json["items"].first["id"]).to eq(item.id)
+        expect(json["items"].first["name"]).to eq(item.name)
+        expect(json["items"].first["purchased"]).to eq(false)
+      end
+    end
+
+    context "未認証の場合" do
+      it "401を返す" do
+        get "/api/v1/shopping_list"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "POST /api/v1/shopping_list/items" do
+    context "認証済みユーザーの場合" do
+      let(:user) { create(:user) }
+      let!(:shopping_list) { create(:shopping_list, user: user) }
+
+      before { sign_in(user, scope: :user) }
+
+      it "アイテムを追加して201を返す" do
+        post "/api/v1/shopping_list/items", params: { shopping_item: { name: "牛乳", memo: "1L" } }
+
+        expect(response).to have_http_status(:created)
+        json = response.parsed_body
+        expect(json["name"]).to eq("牛乳")
+        expect(json["memo"]).to eq("1L")
+        expect(json["purchased"]).to eq(false)
+      end
+
+      it "名前がない場合は422を返す" do
+        post "/api/v1/shopping_list/items", params: { shopping_item: { name: "" } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "PATCH /api/v1/shopping_list/items/:id" do
+    context "認証済みユーザーの場合" do
+      let(:user) { create(:user) }
+      let!(:shopping_list) { create(:shopping_list, user: user) }
+      let!(:item) { create(:shopping_item, shopping_list: shopping_list) }
+
+      before { sign_in(user, scope: :user) }
+
+      it "購入済みトグルを更新して200を返す" do
+        patch "/api/v1/shopping_list/items/#{item.id}", params: { shopping_item: { purchased: true } }
+
+        expect(response).to have_http_status(:ok)
+        expect(item.reload.purchased).to eq(true)
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/shopping_list/items/:id" do
+    context "認証済みユーザーの場合" do
+      let(:user) { create(:user) }
+      let!(:shopping_list) { create(:shopping_list, user: user) }
+      let!(:item) { create(:shopping_item, shopping_list: shopping_list) }
+
+      before { sign_in(user, scope: :user) }
+
+      it "アイテムを削除して204を返す" do
+        delete "/api/v1/shopping_list/items/#{item.id}"
+
+        expect(response).to have_http_status(:no_content)
+        expect(ShoppingItem.find_by(id: item.id)).to be_nil
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/shopping_list/items/purchased" do
+    context "認証済みユーザーの場合" do
+      let(:user) { create(:user) }
+      let!(:shopping_list) { create(:shopping_list, user: user) }
+      let!(:purchased_item) { create(:shopping_item, :purchased, shopping_list: shopping_list) }
+      let!(:unpurchased_item) { create(:shopping_item, shopping_list: shopping_list) }
+
+      before { sign_in(user, scope: :user) }
+
+      it "購入済みアイテムのみ削除して204を返す" do
+        delete "/api/v1/shopping_list/items/purchased"
+
+        expect(response).to have_http_status(:no_content)
+        expect(ShoppingItem.find_by(id: purchased_item.id)).to be_nil
+        expect(ShoppingItem.find_by(id: unpurchased_item.id)).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `rack-cors` を追加し、Next.js フロントエンドからのAPIアクセスを許可（`credentials: true`）
- `/api/v1/` 名前空間に以下のエンドポイントを TDD で実装
  - `GET /api/v1/me` — 認証済みユーザー情報取得
  - `GET /api/v1/shopping_list` — ショッピングリスト＋アイテム一覧
  - `POST /api/v1/shopping_list/items` — アイテム追加
  - `PATCH /api/v1/shopping_list/items/:id` — アイテム更新（購入済みトグル等）
  - `DELETE /api/v1/shopping_list/items/:id` — アイテム削除
  - `DELETE /api/v1/shopping_list/items/purchased` — 購入済み一括削除
  - `GET /api/v1/products` — 商品一覧
- RSpec に `Devise::Test::IntegrationHelpers` を `type: :request` で有効化
- `before(:suite)` でルートを事前描画し `sign_in` ヘルパーを動作させる

## Test plan

- [x] `bundle exec rspec spec/requests/api/v1/` — 全14テスト GREEN
- [x] CI (GitHub Actions) 通過確認

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)