### PR TITLE
feat: ショッピングリスト画面を Next.js に移行する

### DIFF
--- a/frontend/src/app/shopping_list/page.tsx
+++ b/frontend/src/app/shopping_list/page.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState } from "react";
+import { useShoppingList } from "@/hooks/useShoppingList";
+import { ShoppingItemRow } from "@/components/shopping/ShoppingItemRow";
+
+export default function ShoppingListPage() {
+  const { list, isLoading, addItem, togglePurchased, deleteItem, deletePurchased } =
+    useShoppingList();
+  const [name, setName] = useState("");
+  const [memo, setMemo] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setSubmitting(true);
+    try {
+      await addItem({ name: name.trim(), memo: memo.trim() || null });
+      setName("");
+      setMemo("");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  const unpurchased = list?.items.filter((i) => !i.purchased) ?? [];
+  const purchased = list?.items.filter((i) => i.purchased) ?? [];
+
+  return (
+    <div className="min-h-screen bg-orange-50 py-2 px-4 sm:px-6 md:px-8">
+      <div className="w-full max-w-md sm:max-w-lg md:max-w-xl mx-auto bg-white rounded-2xl shadow p-6 md:p-8 border border-orange-100">
+        {/* タイトル */}
+        <h1 className="text-2xl md:text-3xl font-bold text-center text-orange-500 mb-8">
+          🛒 買い物リスト
+        </h1>
+
+        {/* 追加フォーム */}
+        <form onSubmit={handleSubmit} className="space-y-3 mb-8">
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="商品名を入力（例：にんじん）"
+            className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-orange-400 focus:outline-none shadow-sm transition"
+          />
+          <textarea
+            value={memo}
+            onChange={(e) => setMemo(e.target.value)}
+            rows={2}
+            placeholder="メモ（例：広告の品）"
+            className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-orange-400 focus:outline-none shadow-sm transition"
+          />
+          <button
+            type="submit"
+            disabled={submitting || !name.trim()}
+            className="w-full bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white py-2.5 rounded-xl font-semibold shadow-sm transition"
+          >
+            追加
+          </button>
+        </form>
+
+        {/* 未購入品 */}
+        <h2 className="text-lg font-semibold mb-4 text-gray-800">
+          🧺 買うもの
+        </h2>
+        <ul className="space-y-3">
+          {unpurchased.length === 0 && (
+            <li className="text-gray-400 text-sm text-center py-4">
+              まだ商品がありません
+            </li>
+          )}
+          {unpurchased.map((item) => (
+            <ShoppingItemRow
+              key={item.id}
+              item={item}
+              onToggle={togglePurchased}
+              onDelete={deleteItem}
+            />
+          ))}
+        </ul>
+
+        {/* 購入済み */}
+        <div className="mt-10">
+          <div className="flex justify-between items-center mb-3">
+            <h2 className="text-lg font-semibold text-gray-800">
+              ✅ 購入済み
+            </h2>
+            {purchased.length > 0 && (
+              <button
+                type="button"
+                onClick={deletePurchased}
+                className="text-red-500 hover:text-red-600 text-sm font-medium transition"
+              >
+                🗑 購入済みを削除
+              </button>
+            )}
+          </div>
+          <ul className="space-y-3">
+            {purchased.map((item) => (
+              <ShoppingItemRow
+                key={item.id}
+                item={item}
+                onToggle={togglePurchased}
+                onDelete={deleteItem}
+              />
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/shopping/ShoppingItemRow.tsx
+++ b/frontend/src/components/shopping/ShoppingItemRow.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import type { ShoppingItem } from "@/types";
+
+type Props = {
+  item: ShoppingItem;
+  onToggle: (id: number, currentPurchased: boolean) => void;
+  onDelete: (id: number) => void;
+};
+
+/** ショッピングリストの1行 */
+export function ShoppingItemRow({ item, onToggle, onDelete }: Props) {
+  return (
+    <li className="flex justify-between items-center bg-white px-4 py-4 rounded-2xl shadow-sm border border-orange-100 hover:shadow-md transition duration-150 ease-in-out w-full">
+      {/* 商品情報 */}
+      <div className="flex flex-col text-left">
+        <span
+          className={`text-base font-semibold tracking-tight ${
+            item.purchased ? "line-through text-gray-400" : "text-gray-800"
+          }`}
+        >
+          {item.name}
+        </span>
+        {item.memo && (
+          <span
+            className={`text-sm flex items-center gap-1 mt-1 ${
+              item.purchased ? "text-gray-400" : "text-gray-500"
+            }`}
+          >
+            {item.memo}
+          </span>
+        )}
+      </div>
+
+      {/* 操作ボタン */}
+      <div className="flex items-center gap-4">
+        <button
+          type="button"
+          aria-label={item.purchased ? "未購入に戻す" : "購入済みにする"}
+          onClick={() => onToggle(item.id, item.purchased)}
+          className="text-orange-500 hover:text-orange-600 transition"
+        >
+          {item.purchased ? "↩" : "✓"}
+        </button>
+        <button
+          type="button"
+          aria-label="削除"
+          onClick={() => onDelete(item.id)}
+          className="text-red-400 hover:text-red-600 transition"
+        >
+          ✕
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/frontend/src/hooks/useShoppingList.ts
+++ b/frontend/src/hooks/useShoppingList.ts
@@ -1,0 +1,56 @@
+import useSWR from "swr";
+import { apiFetch } from "@/lib/api";
+import type { ShoppingList } from "@/types";
+
+/** ショッピングリストの取得・追加・更新・削除フック */
+export function useShoppingList() {
+  const { data, error, isLoading, mutate } = useSWR<ShoppingList>(
+    "/api/v1/shopping_list",
+    (path: string) => apiFetch<ShoppingList>(path),
+    { shouldRetryOnError: false }
+  );
+
+  /** アイテムを追加する */
+  async function addItem(params: { name: string; memo: string | null }) {
+    await apiFetch("/api/v1/shopping_list/items", {
+      method: "POST",
+      body: JSON.stringify({ shopping_item: params }),
+    });
+    mutate();
+  }
+
+  /** 購入済みトグルを切り替える */
+  async function togglePurchased(id: number, currentPurchased: boolean) {
+    await apiFetch(`/api/v1/shopping_list/items/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify({
+        shopping_item: { purchased: !currentPurchased },
+      }),
+    });
+    mutate();
+  }
+
+  /** アイテムを削除する */
+  async function deleteItem(id: number) {
+    await apiFetch(`/api/v1/shopping_list/items/${id}`, { method: "DELETE" });
+    mutate();
+  }
+
+  /** 購入済みアイテムを一括削除する */
+  async function deletePurchased() {
+    await apiFetch("/api/v1/shopping_list/items/purchased", {
+      method: "DELETE",
+    });
+    mutate();
+  }
+
+  return {
+    list: data,
+    isLoading,
+    error,
+    addItem,
+    togglePurchased,
+    deleteItem,
+    deletePurchased,
+  };
+}

--- a/frontend/tests/components/shopping/ShoppingItemRow.test.tsx
+++ b/frontend/tests/components/shopping/ShoppingItemRow.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ShoppingItemRow } from "@/components/shopping/ShoppingItemRow";
+
+const mockItem = {
+  id: 1,
+  name: "にんじん",
+  memo: "特売品",
+  purchased: false,
+};
+
+describe("ShoppingItemRow", () => {
+  it("商品名とメモが表示される", () => {
+    render(
+      <ShoppingItemRow
+        item={mockItem}
+        onToggle={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("にんじん")).toBeInTheDocument();
+    expect(screen.getByText("特売品")).toBeInTheDocument();
+  });
+
+  it("購入済みの場合、打ち消し線が付く", () => {
+    const purchasedItem = { ...mockItem, purchased: true };
+    render(
+      <ShoppingItemRow
+        item={purchasedItem}
+        onToggle={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    const nameEl = screen.getByText("にんじん");
+    expect(nameEl).toHaveClass("line-through");
+  });
+
+  it("トグルボタンをクリックすると onToggle が呼ばれる", () => {
+    const onToggle = vi.fn();
+    render(
+      <ShoppingItemRow item={mockItem} onToggle={onToggle} onDelete={vi.fn()} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /購入済みにする/ }));
+    expect(onToggle).toHaveBeenCalledWith(1, false);
+  });
+
+  it("削除ボタンをクリックすると onDelete が呼ばれる", () => {
+    const onDelete = vi.fn();
+    render(
+      <ShoppingItemRow
+        item={mockItem}
+        onToggle={vi.fn()}
+        onDelete={onDelete}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /削除/ }));
+    expect(onDelete).toHaveBeenCalledWith(1);
+  });
+});

--- a/frontend/tests/hooks/useShoppingList.test.ts
+++ b/frontend/tests/hooks/useShoppingList.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useShoppingList } from "@/hooks/useShoppingList";
+import type { ShoppingList } from "@/types";
+
+vi.mock("swr");
+vi.mock("@/lib/api");
+
+const mockList: ShoppingList = {
+  id: 1,
+  public_id: "abc-123",
+  name: "買い物リスト",
+  items: [
+    { id: 1, name: "にんじん", memo: null, purchased: false },
+    { id: 2, name: "牛乳", memo: "1L", purchased: true },
+  ],
+};
+
+describe("useShoppingList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("ショッピングリストデータを返す", async () => {
+    const useSWR = (await import("swr")).default;
+    vi.mocked(useSWR).mockReturnValue({
+      data: mockList,
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as ReturnType<typeof useSWR>);
+
+    const { result } = renderHook(() => useShoppingList());
+
+    await waitFor(() => {
+      expect(result.current.list).toEqual(mockList);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  it("addItem を呼ぶと apiFetch POST が実行される", async () => {
+    const useSWR = (await import("swr")).default;
+    const mutate = vi.fn();
+    vi.mocked(useSWR).mockReturnValue({
+      data: mockList,
+      error: undefined,
+      isLoading: false,
+      mutate,
+    } as ReturnType<typeof useSWR>);
+
+    const { apiFetch } = await import("@/lib/api");
+    vi.mocked(apiFetch).mockResolvedValue({
+      id: 3,
+      name: "たまご",
+      memo: null,
+      purchased: false,
+    });
+
+    const { result } = renderHook(() => useShoppingList());
+
+    await act(async () => {
+      await result.current.addItem({ name: "たまご", memo: null });
+    });
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/shopping_list/items", {
+      method: "POST",
+      body: JSON.stringify({ shopping_item: { name: "たまご", memo: null } }),
+    });
+    expect(mutate).toHaveBeenCalled();
+  });
+
+  it("togglePurchased を呼ぶと apiFetch PATCH が実行される", async () => {
+    const useSWR = (await import("swr")).default;
+    const mutate = vi.fn();
+    vi.mocked(useSWR).mockReturnValue({
+      data: mockList,
+      error: undefined,
+      isLoading: false,
+      mutate,
+    } as ReturnType<typeof useSWR>);
+
+    const { apiFetch } = await import("@/lib/api");
+    vi.mocked(apiFetch).mockResolvedValue({
+      id: 1,
+      name: "にんじん",
+      memo: null,
+      purchased: true,
+    });
+
+    const { result } = renderHook(() => useShoppingList());
+
+    await act(async () => {
+      await result.current.togglePurchased(1, false);
+    });
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/shopping_list/items/1", {
+      method: "PATCH",
+      body: JSON.stringify({ shopping_item: { purchased: true } }),
+    });
+    expect(mutate).toHaveBeenCalled();
+  });
+
+  it("deleteItem を呼ぶと apiFetch DELETE が実行される", async () => {
+    const useSWR = (await import("swr")).default;
+    const mutate = vi.fn();
+    vi.mocked(useSWR).mockReturnValue({
+      data: mockList,
+      error: undefined,
+      isLoading: false,
+      mutate,
+    } as ReturnType<typeof useSWR>);
+
+    const { apiFetch } = await import("@/lib/api");
+    vi.mocked(apiFetch).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useShoppingList());
+
+    await act(async () => {
+      await result.current.deleteItem(1);
+    });
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/shopping_list/items/1", {
+      method: "DELETE",
+    });
+    expect(mutate).toHaveBeenCalled();
+  });
+
+  it("deletePurchased を呼ぶと apiFetch DELETE /purchased が実行される", async () => {
+    const useSWR = (await import("swr")).default;
+    const mutate = vi.fn();
+    vi.mocked(useSWR).mockReturnValue({
+      data: mockList,
+      error: undefined,
+      isLoading: false,
+      mutate,
+    } as ReturnType<typeof useSWR>);
+
+    const { apiFetch } = await import("@/lib/api");
+    vi.mocked(apiFetch).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useShoppingList());
+
+    await act(async () => {
+      await result.current.deletePurchased();
+    });
+
+    expect(apiFetch).toHaveBeenCalledWith(
+      "/api/v1/shopping_list/items/purchased",
+      { method: "DELETE" }
+    );
+    expect(mutate).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要

Rails/Hotwire で実装されていたショッピングリスト画面（`/shopping_list`）を Next.js に移行する。
SWR + Rails JSON API でデータを取得し、リアクティブな UI を実現する。

## 変更内容

- `useShoppingList` フックを実装（アイテムの取得・追加・更新・削除）
- `ShoppingItemRow` コンポーネントを実装（購入済みトグル・削除ボタン）
- `app/shopping_list/page.tsx` を実装（追加フォーム・未購入/購入済み一覧・一括削除）

## 対象ファイル

- `frontend/src/hooks/useShoppingList.ts` - SWR + apiFetch でショッピングリスト操作
- `frontend/src/components/shopping/ShoppingItemRow.tsx` - 1アイテムの表示・操作UI
- `frontend/src/app/shopping_list/page.tsx` - ページコンポーネント（Client Component）
- `frontend/tests/hooks/useShoppingList.test.ts` - フックのテスト（5件）
- `frontend/tests/components/shopping/ShoppingItemRow.test.tsx` - コンポーネントのテスト（4件）

## 受入テスト項目

- [ ] ショッピングリストが表示される（未購入・購入済みに分かれている）
- [ ] 商品名を入力して「追加」ボタンで追加できる
- [ ] 購入済みトグルボタンで購入済み/未購入を切り替えられる
- [ ] 削除ボタンでアイテムを削除できる
- [ ] 「購入済みを削除」ボタンで購入済みアイテムを一括削除できる
- [ ] 未認証時は `/login` にリダイレクトされる（次フェーズで実装）

## 影響範囲

- Rails の `/shopping_list` エンドポイントは引き続き動作する（iOS 互換維持）
- Next.js の `/shopping_list` ルートが新たに追加される

## 確認手順

1. `bundle exec rails s` で Rails を起動（port 3000）
2. `cd frontend && npm run dev` で Next.js を起動（port 3001）
3. ブラウザで `http://localhost:3001/shopping_list` にアクセス
4. ログイン済みセッションでショッピングリストが表示されることを確認
5. アイテムの追加・トグル・削除が動作することを確認

## その他

- TDD（RED → GREEN）で開発: 全12テスト GREEN
- `npm run build` でビルド成功確認済み

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)