### PR TITLE
feat: ホーム画面を Next.js に移行する

### DIFF
--- a/app/controllers/api/v1/home_controller.rb
+++ b/app/controllers/api/v1/home_controller.rb
@@ -1,0 +1,59 @@
+module Api
+  module V1
+    class HomeController < BaseController
+      # GET /api/v1/home
+      # 最新5件の価格登録履歴と直近商品のサマリーを返す
+      def index
+        owner = current_user.family_owner
+
+        price_records = owner.price_records
+                             .includes(:product, :shop)
+                             .order(created_at: :desc)
+                             .limit(5)
+
+        render json: {
+          price_records: price_records.map { |r| price_record_json(r) }
+        }
+      end
+
+      # GET /api/v1/home/summary/:product_id
+      # 指定商品の価格サマリーを返す
+      def summary
+        owner = current_user.family_owner
+        product = owner.products.find_by(id: params[:product_id])
+
+        unless product
+          render json: { error: "商品が見つかりません" }, status: :not_found
+          return
+        end
+
+        histories = product.price_records
+
+        render json: {
+          product_id: product.id,
+          product_name: product.name,
+          min_price: histories.minimum(:price),
+          max_price: histories.maximum(:price),
+          average_price: histories.average(:price)&.round,
+          last_price: histories.order(purchased_at: :desc).first&.price,
+          last_purchased_at: histories.order(purchased_at: :desc).first&.purchased_at
+        }
+      end
+
+      private
+
+      def price_record_json(record)
+        {
+          id: record.id,
+          price: record.price,
+          memo: record.memo,
+          purchased_at: record.purchased_at,
+          product_id: record.product.id,
+          product_name: record.product.name,
+          product_public_id: record.product.public_id,
+          shop_name: record.shop&.name
+        }
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,10 @@ Rails.application.routes.draw do
       delete "shopping_list/items/purchased",  to: "shopping_list#delete_purchased"
       delete "shopping_list/items/:id",        to: "shopping_list#destroy_item"
 
+      # ホーム（価格登録履歴・価格サマリー）
+      get "home", to: "home#index"
+      get "home/summary/:product_id", to: "home#summary", as: :home_summary
+
       # 商品
       resources :products, only: [ :index ]
     end

--- a/frontend/src/app/home/page.tsx
+++ b/frontend/src/app/home/page.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+import { useHome, usePriceSummary } from "@/hooks/useHome";
+import type { PriceRecord, PriceSummary } from "@/types";
+
+/** 価格サマリーカード */
+function PriceSummaryCard({ summary }: { summary: PriceSummary | undefined }) {
+  if (!summary) return null;
+
+  const hasData =
+    summary.min_price !== null || summary.max_price !== null;
+
+  return (
+    <div className="bg-white rounded-2xl shadow border border-orange-100 p-6 mb-8">
+      <h2 className="text-xl font-bold text-gray-800 mb-5">
+        📈 価格サマリー
+        {summary.product_name && (
+          <span className="text-base font-normal text-gray-500 ml-2">
+            — {summary.product_name}
+          </span>
+        )}
+      </h2>
+      {!hasData ? (
+        <p className="text-center text-gray-500 py-4">
+          まだ価格の登録がありません。
+        </p>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-4 text-center">
+            <div className="bg-orange-50 border border-orange-100 rounded-xl py-3">
+              <p className="text-sm text-gray-600">最安値</p>
+              <p className="text-lg font-bold text-orange-600 mt-1">
+                {summary.min_price != null
+                  ? `¥${summary.min_price.toLocaleString()}`
+                  : "---"}
+              </p>
+            </div>
+            <div className="bg-orange-50 border border-orange-100 rounded-xl py-3">
+              <p className="text-sm text-gray-600">最高値</p>
+              <p className="text-lg font-bold text-gray-700 mt-1">
+                {summary.max_price != null
+                  ? `¥${summary.max_price.toLocaleString()}`
+                  : "---"}
+              </p>
+            </div>
+          </div>
+          <div className="mt-5 flex justify-between items-center border-t border-orange-100 pt-4">
+            <p className="text-sm text-gray-600">⚖ 平均価格</p>
+            <p className="text-lg font-semibold text-gray-700">
+              {summary.average_price != null
+                ? `¥${summary.average_price.toLocaleString()}`
+                : "---"}
+            </p>
+          </div>
+          <div className="mt-3 flex justify-between items-center">
+            <p className="text-sm text-gray-600">🕐 前回購入</p>
+            <p className="text-base text-gray-700 font-medium">
+              {summary.last_price != null
+                ? `¥${summary.last_price.toLocaleString()}`
+                : "---"}
+              <span className="text-sm text-gray-500 ml-1">
+                ({summary.last_purchased_at ?? "----/--/--"})
+              </span>
+            </p>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+/** 価格履歴の1件 */
+function PriceRecordCard({
+  record,
+  onSelect,
+}: {
+  record: PriceRecord;
+  onSelect: (id: number) => void;
+}) {
+  return (
+    <div
+      className="bg-white border border-orange-100 shadow-sm hover:shadow-md transition rounded-2xl p-5 cursor-pointer"
+      onClick={() => onSelect(record.product_id)}
+    >
+      <div className="flex justify-between items-start mb-2 gap-3">
+        <h3 className="text-lg font-semibold text-gray-800">
+          {record.product_name}
+        </h3>
+        <p className="text-lg font-bold text-orange-500 whitespace-nowrap">
+          ¥{record.price.toLocaleString()}
+        </p>
+      </div>
+      <p className="text-sm text-gray-600 mb-1">
+        店舗：{record.shop_name ?? "未登録"} ／ 日付：{record.purchased_at}
+      </p>
+      {record.memo && (
+        <p className="text-xs text-gray-500 mt-1 bg-orange-50 p-2 rounded-md border border-orange-100">
+          {record.memo}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function HomePage() {
+  const { priceRecords, isLoading } = useHome();
+  const [selectedProductId, setSelectedProductId] = useState<number | null>(
+    null
+  );
+  const { summary } = usePriceSummary(selectedProductId);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-orange-50 py-10 px-4 sm:px-6 md:px-10">
+      <div className="max-w-3xl mx-auto">
+        <h1 className="text-2xl sm:text-3xl font-extrabold text-center text-orange-500 mb-10">
+          🏠 ホーム
+        </h1>
+
+        {/* 価格サマリー */}
+        <PriceSummaryCard summary={summary} />
+
+        {/* 価格登録履歴 */}
+        <h2 className="text-xl font-bold text-gray-700 mt-10 mb-5">
+          🕐 価格登録履歴（新着順）
+        </h2>
+        <div className="space-y-4">
+          {priceRecords.length === 0 ? (
+            <p className="text-gray-500 text-center">
+              まだ価格の登録がありません。
+            </p>
+          ) : (
+            priceRecords.map((record) => (
+              <PriceRecordCard
+                key={record.id}
+                record={record}
+                onSelect={setSelectedProductId}
+              />
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useHome.ts
+++ b/frontend/src/hooks/useHome.ts
@@ -1,0 +1,33 @@
+import useSWR from "swr";
+import { apiFetch } from "@/lib/api";
+import type { PriceRecord, PriceSummary } from "@/types";
+
+type HomeData = {
+  price_records: PriceRecord[];
+};
+
+/** ホーム画面の価格登録履歴を取得するフック */
+export function useHome() {
+  const { data, error, isLoading } = useSWR<HomeData>(
+    "/api/v1/home",
+    (path: string) => apiFetch<HomeData>(path),
+    { shouldRetryOnError: false }
+  );
+
+  return {
+    priceRecords: data?.price_records ?? [],
+    isLoading,
+    error,
+  };
+}
+
+/** 指定商品の価格サマリーを取得するフック */
+export function usePriceSummary(productId: number | null) {
+  const { data, error, isLoading } = useSWR<PriceSummary>(
+    productId ? `/api/v1/home/summary/${productId}` : null,
+    (path: string) => apiFetch<PriceSummary>(path),
+    { shouldRetryOnError: false }
+  );
+
+  return { summary: data, isLoading, error };
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -25,6 +25,29 @@ export type ShoppingList = {
   items: ShoppingItem[];
 };
 
+/** 価格登録履歴（ホーム画面用） */
+export type PriceRecord = {
+  id: number;
+  price: number;
+  memo: string | null;
+  purchased_at: string;
+  product_id: number;
+  product_name: string;
+  product_public_id: string;
+  shop_name: string | null;
+};
+
+/** 価格サマリー（ホーム画面用） */
+export type PriceSummary = {
+  product_id: number;
+  product_name: string;
+  min_price: number | null;
+  max_price: number | null;
+  average_price: number | null;
+  last_price: number | null;
+  last_purchased_at: string | null;
+};
+
 /** 商品 */
 export type Product = {
   id: number;

--- a/frontend/tests/hooks/useHome.test.ts
+++ b/frontend/tests/hooks/useHome.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useHome } from "@/hooks/useHome";
+import type { PriceRecord } from "@/types";
+
+vi.mock("swr");
+
+const mockRecords: PriceRecord[] = [
+  {
+    id: 1,
+    price: 198,
+    memo: null,
+    purchased_at: "2024-01-01",
+    product_id: 10,
+    product_name: "牛乳",
+    product_public_id: "abc",
+    shop_name: "イオン",
+  },
+];
+
+describe("useHome", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("価格登録履歴を返す", async () => {
+    const useSWR = (await import("swr")).default;
+    vi.mocked(useSWR).mockReturnValue({
+      data: { price_records: mockRecords },
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as ReturnType<typeof useSWR>);
+
+    const { result } = renderHook(() => useHome());
+
+    await waitFor(() => {
+      expect(result.current.priceRecords).toEqual(mockRecords);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  it("データがない場合は空配列を返す", async () => {
+    const useSWR = (await import("swr")).default;
+    vi.mocked(useSWR).mockReturnValue({
+      data: { price_records: [] },
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as ReturnType<typeof useSWR>);
+
+    const { result } = renderHook(() => useHome());
+
+    await waitFor(() => {
+      expect(result.current.priceRecords).toEqual([]);
+    });
+  });
+});

--- a/spec/requests/api/v1/home_spec.rb
+++ b/spec/requests/api/v1/home_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Home", type: :request do
+  describe "GET /api/v1/home" do
+    context "認証済みユーザーの場合" do
+      let(:user) { create(:user) }
+
+      before { sign_in(user, scope: :user) }
+
+      it "200と最新5件の価格登録履歴をJSONで返す" do
+        product = create(:product, user: user)
+        shop = create(:shop, user: user)
+        6.times { |i| create(:price_record, user: user, product: product, shop: shop, price: 100 + i) }
+
+        get "/api/v1/home"
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json["price_records"].length).to eq(5)
+      end
+
+      it "price_recordsに必要なフィールドが含まれる" do
+        product = create(:product, user: user, name: "牛乳")
+        shop = create(:shop, user: user, name: "イオン")
+        create(:price_record, user: user, product: product, shop: shop, price: 198)
+
+        get "/api/v1/home"
+
+        json = response.parsed_body
+        record = json["price_records"].first
+        expect(record["price"]).to eq(198)
+        expect(record["product_name"]).to eq("牛乳")
+        expect(record["shop_name"]).to eq("イオン")
+        expect(record).to have_key("purchased_at")
+        expect(record).to have_key("memo")
+      end
+
+      it "価格登録がない場合は空配列を返す" do
+        get "/api/v1/home"
+
+        json = response.parsed_body
+        expect(json["price_records"]).to eq([])
+      end
+    end
+
+    context "未認証の場合" do
+      it "401を返す" do
+        get "/api/v1/home"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "GET /api/v1/home/summary/:product_id" do
+    context "認証済みユーザーの場合" do
+      let(:user) { create(:user) }
+      let(:product) { create(:product, user: user) }
+
+      before { sign_in(user, scope: :user) }
+
+      it "200と価格サマリーをJSONで返す" do
+        create(:price_record, user: user, product: product, price: 100)
+        create(:price_record, user: user, product: product, price: 200)
+        create(:price_record, user: user, product: product, price: 150)
+
+        get "/api/v1/home/summary/#{product.id}"
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json["min_price"]).to eq(100)
+        expect(json["max_price"]).to eq(200)
+        expect(json["average_price"]).to eq(150)
+        expect(json["product_name"]).to eq(product.name)
+      end
+
+      it "存在しない商品IDは404を返す" do
+        get "/api/v1/home/summary/999999"
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "未認証の場合" do
+      it "401を返す" do
+        get "/api/v1/home/summary/1"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Rails/Hotwire で実装されていたホーム画面（`/home`）を Next.js に移行する。
価格登録履歴（最新5件）と価格サマリー（最安値・最高値・平均・前回）を表示する。

## 変更内容

**Rails API:**
- `GET /api/v1/home` — 最新5件の価格登録履歴を返す
- `GET /api/v1/home/summary/:product_id` — 商品の価格サマリーを返す

**Next.js:**
- `useHome` フック: 価格登録履歴の取得
- `usePriceSummary` フック: 商品価格サマリーの取得（productId=null のときリクエストしない）
- `app/home/page.tsx`: 価格サマリーカード + 履歴一覧（履歴行クリックでサマリー切替）

## 対象ファイル

- `app/controllers/api/v1/home_controller.rb` — Rails API コントローラー（新規）
- `config/routes.rb` — `/api/v1/home` ルート追加
- `spec/requests/api/v1/home_spec.rb` — Rails API テスト（7件）
- `frontend/src/hooks/useHome.ts` — useHome / usePriceSummary フック
- `frontend/src/app/home/page.tsx` — ホームページコンポーネント
- `frontend/src/types/index.ts` — PriceRecord / PriceSummary 型定義追加
- `frontend/tests/hooks/useHome.test.ts` — フックのテスト（2件）

## 受入テスト項目

- [ ] `/home` にアクセスすると価格登録履歴が表示される
- [ ] 履歴がない場合「まだ価格の登録がありません。」が表示される
- [ ] 履歴行をクリックすると、その商品の価格サマリーが表示される
- [ ] 価格サマリーに最安値・最高値・平均価格・前回購入価格が表示される
- [ ] 未認証時は 401 が返る（Next.js 側は次フェーズでリダイレクト実装）

## 影響範囲

- Rails の既存 `/home` エンドポイントはそのまま動作する（iOS 互換）
- Next.js の `/home` ルートが新たに追加される

## 確認手順

1. `bundle exec rails s` で Rails を起動（port 3000）
2. `cd frontend && npm run dev` で Next.js を起動（port 3001）
3. `http://localhost:3001/home` にアクセスして履歴が表示されることを確認
4. 履歴行クリックで価格サマリーが更新されることを確認

## その他

- TDD（RED → GREEN）: Rails 7テスト + Next.js 2テスト (全14テスト GREEN)
- `npm run build` でビルド成功確認済み

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)