### PR TITLE
feat: 価格記録登録画面を Next.js に移行する

### DIFF
--- a/app/controllers/api/v1/price_records_controller.rb
+++ b/app/controllers/api/v1/price_records_controller.rb
@@ -1,0 +1,102 @@
+module Api
+  module V1
+    class PriceRecordsController < BaseController
+      before_action :set_price_record, only: [ :update, :destroy ]
+
+      # GET /api/v1/price_records/form_data
+      # フォームで使うshops・categories・productsを返す
+      def form_data
+        owner = current_user.family_owner
+
+        render json: {
+          shops: owner.shops.order(:name).map { |s| { id: s.id, name: s.name } },
+          categories: owner.categories.order(:name).map { |c| { id: c.id, name: c.name } },
+          products: owner.products.order(:name).map { |p|
+            { id: p.id, public_id: p.public_id, name: p.name,
+              category_id: p.category_id }
+          }
+        }
+      end
+
+      # POST /api/v1/price_records
+      def create
+        owner = current_user.family_owner
+        record = current_user.price_records.new(base_params)
+
+        product = resolve_product(owner)
+        unless product
+          render json: { error: "商品情報が不正です" }, status: :unprocessable_entity
+          return
+        end
+
+        record.product = product
+
+        if record.save
+          render json: price_record_json(record), status: :created
+        else
+          render json: { errors: record.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # PATCH /api/v1/price_records/:id
+      def update
+        if @price_record.update(update_params)
+          render json: price_record_json(@price_record)
+        else
+          render json: { errors: @price_record.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # DELETE /api/v1/price_records/:id
+      def destroy
+        @price_record.destroy!
+        head :no_content
+      end
+
+      private
+
+      def set_price_record
+        owner = current_user.family_owner
+        @price_record = owner.price_records.find_by(public_id: params[:id])
+        render json: { error: "見つかりません" }, status: :not_found unless @price_record
+      end
+
+      # 既存商品IDまたは新規商品名＋カテゴリーから商品を解決する
+      def resolve_product(owner)
+        product_id = params.dig(:price_record, :product_id)
+        product_name = params.dig(:price_record, :product_name)
+        category_id = params.dig(:price_record, :category_id)
+
+        if product_id.present?
+          owner.products.find_by(id: product_id)
+        elsif product_name.present? && category_id.present?
+          owner.products.find_or_create_by(name: product_name) do |p|
+            p.category_id = category_id
+          end
+        end
+      end
+
+      def base_params
+        params.require(:price_record).permit(:price, :memo, :purchased_at, :shop_id)
+      end
+
+      def update_params
+        params.require(:price_record).permit(:price, :memo, :purchased_at, :shop_id)
+      end
+
+      def price_record_json(record)
+        {
+          id: record.id,
+          public_id: record.public_id,
+          price: record.price,
+          memo: record.memo,
+          purchased_at: record.purchased_at,
+          product_id: record.product_id,
+          product_name: record.product.name,
+          shop_id: record.shop_id,
+          shop_name: record.shop&.name
+        }
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,13 @@ Rails.application.routes.draw do
       get "home", to: "home#index"
       get "home/summary/:product_id", to: "home#summary", as: :home_summary
 
+      # 価格記録
+      resources :price_records, only: [ :create, :update, :destroy ] do
+        collection do
+          get :form_data
+        end
+      end
+
       # 商品
       resources :products, only: [ :index ]
     end

--- a/frontend/src/app/price_records/new/page.tsx
+++ b/frontend/src/app/price_records/new/page.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { usePriceRecordForm } from "@/hooks/usePriceRecordForm";
+
+export default function NewPriceRecordPage() {
+  const router = useRouter();
+  const { formData, isLoading, createPriceRecord } = usePriceRecordForm();
+
+  const [productId, setProductId] = useState<number | null>(null);
+  const [productName, setProductName] = useState("");
+  const [categoryId, setCategoryId] = useState<number | null>(null);
+  const [shopId, setShopId] = useState<number | null>(null);
+  const [price, setPrice] = useState("");
+  const [purchasedAt, setPurchasedAt] = useState(
+    new Date().toISOString().split("T")[0]
+  );
+  const [memo, setMemo] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  // 商品名入力で既存商品を選択する
+  const matchedProduct = formData?.products.find(
+    (p) => p.name === productName.trim()
+  );
+  const isNewProduct = productName.trim() !== "" && !matchedProduct;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErrors([]);
+
+    if (!price || Number(price) <= 0) {
+      setErrors(["価格を入力してください"]);
+      return;
+    }
+
+    if (!productId && !matchedProduct && !productName.trim()) {
+      setErrors(["商品名を入力してください"]);
+      return;
+    }
+
+    if (isNewProduct && !categoryId) {
+      setErrors(["新規商品の場合はカテゴリーを選択してください"]);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const resolvedProductId = productId ?? matchedProduct?.id;
+      await createPriceRecord({
+        ...(resolvedProductId
+          ? { product_id: resolvedProductId }
+          : { product_name: productName.trim(), category_id: categoryId! }),
+        shop_id: shopId,
+        price: Number(price),
+        purchased_at: purchasedAt,
+        memo: memo.trim() || null,
+      });
+      router.push("/home");
+    } catch {
+      setErrors(["登録に失敗しました"]);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-orange-50 py-6 px-4 sm:px-6 md:px-10">
+      <div className="max-w-md mx-auto bg-white rounded-2xl shadow p-6 sm:p-8 border border-orange-100">
+        <h1 className="text-xl sm:text-2xl font-bold text-center text-orange-500 mb-8">
+          🏷 価格登録
+        </h1>
+
+        {errors.length > 0 && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-xl text-sm text-red-600">
+            {errors.map((e, i) => (
+              <p key={i}>{e}</p>
+            ))}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          {/* 商品名 */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              商品名
+            </label>
+            <input
+              type="text"
+              value={productName}
+              onChange={(e) => {
+                setProductName(e.target.value);
+                setProductId(null);
+              }}
+              placeholder="例：牛乳"
+              list="product-list"
+              className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
+            />
+            <datalist id="product-list">
+              {formData?.products.map((p) => (
+                <option key={p.id} value={p.name} />
+              ))}
+            </datalist>
+          </div>
+
+          {/* カテゴリー（新規商品のときのみ表示） */}
+          {isNewProduct && (
+            <div>
+              <label className="block text-sm font-semibold text-gray-700 mb-1">
+                カテゴリー（新規商品）
+              </label>
+              <select
+                value={categoryId ?? ""}
+                onChange={(e) =>
+                  setCategoryId(e.target.value ? Number(e.target.value) : null)
+                }
+                className="w-full border border-gray-300 rounded-xl p-3 bg-white focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
+              >
+                <option value="">選択してください</option>
+                {formData?.categories.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {/* 店舗 */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              店舗
+            </label>
+            <select
+              value={shopId ?? ""}
+              onChange={(e) =>
+                setShopId(e.target.value ? Number(e.target.value) : null)
+              }
+              className="w-full border border-gray-300 rounded-xl p-3 bg-white focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
+            >
+              <option value="">選択してください</option>
+              {formData?.shops.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* 価格 */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              価格
+            </label>
+            <input
+              type="number"
+              value={price}
+              onChange={(e) => setPrice(e.target.value)}
+              min={1}
+              step={1}
+              placeholder="例：198"
+              className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
+            />
+          </div>
+
+          {/* 日付 */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              日付
+            </label>
+            <input
+              type="date"
+              value={purchasedAt}
+              onChange={(e) => setPurchasedAt(e.target.value)}
+              className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
+            />
+          </div>
+
+          {/* メモ */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              メモ
+            </label>
+            <textarea
+              value={memo}
+              onChange={(e) => setMemo(e.target.value)}
+              rows={3}
+              placeholder="例：広告の品、まとめ買いなど"
+              className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white font-bold py-2.5 rounded-full shadow-md transition"
+          >
+            登録する
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/usePriceRecordForm.ts
+++ b/frontend/src/hooks/usePriceRecordForm.ts
@@ -1,0 +1,57 @@
+import useSWR from "swr";
+import { apiFetch } from "@/lib/api";
+import type { PriceRecordFormData } from "@/types";
+
+type CreateParams = {
+  product_id?: number;
+  product_name?: string;
+  category_id?: number;
+  shop_id?: number | null;
+  price: number;
+  purchased_at: string;
+  memo: string | null;
+};
+
+/** 価格記録フォームのデータ取得・送信フック */
+export function usePriceRecordForm() {
+  const { data, error, isLoading } = useSWR<PriceRecordFormData>(
+    "/api/v1/price_records/form_data",
+    (path: string) => apiFetch<PriceRecordFormData>(path),
+    { shouldRetryOnError: false }
+  );
+
+  /** 価格記録を新規登録する */
+  async function createPriceRecord(params: CreateParams) {
+    return apiFetch("/api/v1/price_records", {
+      method: "POST",
+      body: JSON.stringify({ price_record: params }),
+    });
+  }
+
+  /** 価格記録を更新する */
+  async function updatePriceRecord(
+    publicId: string,
+    params: Partial<CreateParams>
+  ) {
+    return apiFetch(`/api/v1/price_records/${publicId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ price_record: params }),
+    });
+  }
+
+  /** 価格記録を削除する */
+  async function deletePriceRecord(publicId: string) {
+    return apiFetch(`/api/v1/price_records/${publicId}`, {
+      method: "DELETE",
+    });
+  }
+
+  return {
+    formData: data,
+    isLoading,
+    error,
+    createPriceRecord,
+    updatePriceRecord,
+    deletePriceRecord,
+  };
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -48,6 +48,13 @@ export type PriceSummary = {
   last_purchased_at: string | null;
 };
 
+/** 価格記録フォームデータ */
+export type PriceRecordFormData = {
+  shops: { id: number; name: string }[];
+  categories: { id: number; name: string }[];
+  products: { id: number; public_id: string; name: string; category_id: number | null }[];
+};
+
 /** 商品 */
 export type Product = {
   id: number;

--- a/frontend/tests/hooks/usePriceRecordForm.test.ts
+++ b/frontend/tests/hooks/usePriceRecordForm.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { usePriceRecordForm } from "@/hooks/usePriceRecordForm";
+
+vi.mock("swr");
+vi.mock("@/lib/api");
+
+const mockFormData = {
+  shops: [{ id: 1, name: "イオン" }],
+  categories: [{ id: 1, name: "野菜" }],
+  products: [{ id: 10, public_id: "abc", name: "牛乳", category_id: null }],
+};
+
+describe("usePriceRecordForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("フォーム用データ（shops・categories・products）を返す", async () => {
+    const useSWR = (await import("swr")).default;
+    vi.mocked(useSWR).mockReturnValue({
+      data: mockFormData,
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as ReturnType<typeof useSWR>);
+
+    const { result } = renderHook(() => usePriceRecordForm());
+
+    await waitFor(() => {
+      expect(result.current.formData?.shops[0].name).toBe("イオン");
+      expect(result.current.formData?.categories[0].name).toBe("野菜");
+      expect(result.current.formData?.products[0].name).toBe("牛乳");
+    });
+  });
+
+  it("createPriceRecord を呼ぶと POST が実行される", async () => {
+    const useSWR = (await import("swr")).default;
+    vi.mocked(useSWR).mockReturnValue({
+      data: mockFormData,
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as ReturnType<typeof useSWR>);
+
+    const { apiFetch } = await import("@/lib/api");
+    vi.mocked(apiFetch).mockResolvedValue({ id: 1, price: 198 });
+
+    const { result } = renderHook(() => usePriceRecordForm());
+
+    await act(async () => {
+      await result.current.createPriceRecord({
+        product_id: 10,
+        shop_id: 1,
+        price: 198,
+        purchased_at: "2024-01-15",
+        memo: null,
+      });
+    });
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/price_records", {
+      method: "POST",
+      body: expect.stringContaining('"price":198'),
+    });
+  });
+});

--- a/spec/requests/api/v1/price_records_spec.rb
+++ b/spec/requests/api/v1/price_records_spec.rb
@@ -1,0 +1,129 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::PriceRecords", type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in(user, scope: :user) }
+
+  describe "GET /api/v1/price_records/form_data" do
+    it "200とフォーム用データ（shops・categories・products）を返す" do
+      create(:shop, user: user, name: "イオン")
+      create(:category, user: user, name: "野菜")
+
+      get "/api/v1/price_records/form_data"
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json["shops"].map { |s| s["name"] }).to include("イオン")
+      expect(json["categories"].map { |c| c["name"] }).to include("野菜")
+      expect(json).to have_key("products")
+    end
+  end
+
+  describe "POST /api/v1/price_records" do
+    context "既存商品IDを指定した場合" do
+      it "201と登録された価格記録を返す" do
+        product = create(:product, user: user)
+        shop = create(:shop, user: user)
+
+        post "/api/v1/price_records", params: {
+          price_record: {
+            product_id: product.id,
+            shop_id: shop.id,
+            price: 198,
+            purchased_at: "2024-01-15",
+            memo: "特売"
+          }
+        }
+
+        expect(response).to have_http_status(:created)
+        json = response.parsed_body
+        expect(json["price"]).to eq(198)
+        expect(json["product_name"]).to eq(product.name)
+      end
+    end
+
+    context "新規商品名+カテゴリーを指定した場合" do
+      it "201と価格記録を返し、商品も新規作成される" do
+        category = create(:category, user: user)
+        shop = create(:shop, user: user)
+
+        post "/api/v1/price_records", params: {
+          price_record: {
+            product_name: "新しい商品",
+            category_id: category.id,
+            shop_id: shop.id,
+            price: 298,
+            purchased_at: "2024-01-15"
+          }
+        }
+
+        expect(response).to have_http_status(:created)
+        expect(Product.find_by(name: "新しい商品")).to be_present
+      end
+    end
+
+    context "price が空の場合" do
+      it "422を返す" do
+        product = create(:product, user: user)
+
+        post "/api/v1/price_records", params: {
+          price_record: {
+            product_id: product.id,
+            price: nil,
+            purchased_at: "2024-01-15"
+          }
+        }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "PATCH /api/v1/price_records/:id" do
+    it "200と更新された価格記録を返す" do
+      product = create(:product, user: user)
+      record = create(:price_record, user: user, product: product, price: 100)
+
+      patch "/api/v1/price_records/#{record.public_id}", params: {
+        price_record: { price: 150, memo: "更新メモ" }
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(record.reload.price).to eq(150)
+    end
+
+    it "他ユーザーの価格記録は更新できない" do
+      other_user = create(:user)
+      product = create(:product, user: other_user)
+      record = create(:price_record, user: other_user, product: product)
+
+      patch "/api/v1/price_records/#{record.public_id}", params: {
+        price_record: { price: 999 }
+      }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "DELETE /api/v1/price_records/:id" do
+    it "204を返し価格記録が削除される" do
+      product = create(:product, user: user)
+      record = create(:price_record, user: user, product: product)
+
+      delete "/api/v1/price_records/#{record.public_id}"
+
+      expect(response).to have_http_status(:no_content)
+      expect(PriceRecord.find_by(id: record.id)).to be_nil
+    end
+  end
+
+  describe "未認証の場合" do
+    before { sign_out :user }
+
+    it "401を返す" do
+      get "/api/v1/price_records/form_data"
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

価格記録の登録フォーム（`/price_records/new`）を Next.js に移行する。
既存商品の選択・新規商品の作成を1画面で行える。

## 変更内容

**Rails API:**
- `GET /api/v1/price_records/form_data` — shops・categories・products を返す
- `POST /api/v1/price_records` — 既存商品ID or 新規商品名+カテゴリーで登録
- `PATCH /api/v1/price_records/:id` — 価格記録の更新
- `DELETE /api/v1/price_records/:id` — 価格記録の削除

**Next.js:**
- `usePriceRecordForm` フック: フォームデータ取得・登録・更新・削除
- `app/price_records/new/page.tsx`: 登録フォーム
  - 商品名入力 + datalist で既存商品をサジェスト
  - 新規商品を入力した場合のみカテゴリー選択を表示
  - 店舗・価格・日付・メモ

## 対象ファイル

- `app/controllers/api/v1/price_records_controller.rb` — Rails API（新規）
- `config/routes.rb` — `/api/v1/price_records` ルート追加
- `spec/requests/api/v1/price_records_spec.rb` — Rails API テスト（8件）
- `frontend/src/hooks/usePriceRecordForm.ts` — フォームフック
- `frontend/src/app/price_records/new/page.tsx` — 登録フォームページ
- `frontend/src/types/index.ts` — PriceRecordFormData 型追加
- `frontend/tests/hooks/usePriceRecordForm.test.ts` — フックのテスト（2件）

## 受入テスト項目

- [ ] `/price_records/new` にアクセスするとフォームが表示される
- [ ] 商品名を入力すると既存商品が datalist でサジェストされる
- [ ] 既存商品にない名前を入力するとカテゴリー選択が表示される
- [ ] 価格・日付を入力して「登録する」で登録後、`/home` にリダイレクトされる
- [ ] 価格が空の場合はエラーメッセージが表示される
- [ ] 未認証時は 401 が返る

## 影響範囲

- Rails の既存 `/price_records/new` はそのまま動作（iOS 互換）
- Next.js に `/price_records/new` ルートが追加される

## 確認手順

1. `bundle exec rails s` で Rails を起動（port 3000）
2. `cd frontend && npm run dev` で Next.js を起動（port 3001）
3. `http://localhost:3001/price_records/new` にアクセス
4. 商品名入力・店舗選択・価格入力で登録できることを確認

## その他

- TDD（RED → GREEN）: Rails 8テスト + Next.js 2テスト（全16テスト GREEN）
- `npm run build` でビルド成功確認済み

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)