### PR TITLE
Phase 3-6: ファミリー機能 Next.js 移行

### DIFF
--- a/app/controllers/api/v1/family_controller.rb
+++ b/app/controllers/api/v1/family_controller.rb
@@ -1,0 +1,132 @@
+module Api
+  module V1
+    class FamilyController < BaseController
+      before_action :require_family!, only: [ :show, :update, :destroy, :leave, :transfer_owner, :regenerate_invite ]
+      before_action :require_family_admin!, only: [ :update, :destroy, :transfer_owner, :regenerate_invite ]
+
+      # GET /api/v1/family
+      def show
+        render json: family_json(current_user.family)
+      end
+
+      # POST /api/v1/family
+      def create
+        if current_user.family.present?
+          render json: { error: "すでにファミリーに所属しています" }, status: :unprocessable_entity
+          return
+        end
+
+        family = Family.new(family_params)
+        family.owner = current_user
+        family.base_user = current_user
+
+        ActiveRecord::Base.transaction do
+          family.save!
+          current_user.update!(family: family, family_role: :family_admin)
+        end
+
+        render json: family_json(family), status: :created
+      rescue => e
+        render json: { error: "作成できませんでした" }, status: :unprocessable_entity
+      end
+
+      # PATCH /api/v1/family
+      def update
+        if current_user.family.update(family_params)
+          render json: family_json(current_user.family)
+        else
+          render json: { errors: current_user.family.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # DELETE /api/v1/family
+      def destroy
+        family = current_user.family
+        ActiveRecord::Base.transaction do
+          family.users.update_all(family_id: nil, family_role: User.family_roles[:personal])
+          family.destroy!
+        end
+        render json: { message: "ファミリーを解散しました" }
+      rescue => e
+        render json: { error: "解散できませんでした" }, status: :unprocessable_entity
+      end
+
+      # DELETE /api/v1/family/leave
+      def leave
+        if current_user.family_admin?
+          render json: { error: "管理者は権限を譲渡してから脱退してください" }, status: :unprocessable_entity
+          return
+        end
+
+        current_user.update!(family_id: nil, family_role: :personal)
+        render json: { message: "ファミリーから脱退しました" }
+      end
+
+      # PATCH /api/v1/family/transfer_owner
+      def transfer_owner
+        family = current_user.family
+        new_owner = family.users.find_by(id: params[:member_id])
+
+        unless new_owner
+          render json: { error: "メンバーが見つかりません" }, status: :not_found
+          return
+        end
+
+        if new_owner == current_user
+          render json: { error: "自分自身に譲渡することはできません" }, status: :unprocessable_entity
+          return
+        end
+
+        ActiveRecord::Base.transaction do
+          family.update!(owner: new_owner)
+          current_user.update!(family_role: :family_member)
+          new_owner.update!(family_role: :family_admin)
+        end
+
+        render json: family_json(family.reload)
+      rescue => e
+        render json: { error: "権限を譲渡できませんでした" }, status: :unprocessable_entity
+      end
+
+      # POST /api/v1/family/regenerate_invite
+      def regenerate_invite
+        current_user.family.regenerate_invite_token!
+        render json: family_json(current_user.family)
+      end
+
+      private
+
+      def require_family!
+        unless current_user.family.present?
+          render json: { error: "ファミリーに所属していません" }, status: :not_found
+        end
+      end
+
+      def require_family_admin!
+        unless current_user.family_admin?
+          render json: { error: "権限がありません" }, status: :forbidden
+        end
+      end
+
+      def family_params
+        params.require(:family).permit(:name)
+      end
+
+      def family_json(family)
+        {
+          id: family.id,
+          name: family.name,
+          invite_token: family.invite_token,
+          members_count: family.users.count,
+          members: family.users.order(:id).map { |u|
+            {
+              id: u.id,
+              nickname: u.nickname,
+              family_role: u.family_role
+            }
+          }
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/family_invites_controller.rb
+++ b/app/controllers/api/v1/family_invites_controller.rb
@@ -1,0 +1,73 @@
+module Api
+  module V1
+    class FamilyInvitesController < BaseController
+      skip_before_action :authenticate_user!, only: [ :show ]
+
+      # GET /api/v1/family_invites/:token
+      # 認証不要: 招待リンクを開いたとき（未ログインでも家族名などを表示したい）
+      def show
+        family = Family.find_by(invite_token: params[:token])
+        unless family
+          render json: { error: "無効な招待リンクです" }, status: :not_found
+          return
+        end
+
+        render json: {
+          name: family.name,
+          members_count: family.users.count,
+          remaining_slots: family.remaining_slots
+        }
+      end
+
+      # POST /api/v1/family_invites/:token/join
+      def join
+        family = Family.find_by(invite_token: params[:token])
+        unless family
+          render json: { error: "無効な招待リンクです" }, status: :not_found
+          return
+        end
+
+        if current_user.family_admin? || current_user.family_member?
+          render json: { error: "すでに別のファミリーに所属しています" }, status: :unprocessable_entity
+          return
+        end
+
+        Family.transaction do
+          family.lock!
+          if family.full?
+            render json: { error: "このファミリーは上限人数(#{Family::MAX_MEMBERS}名)に達しています" },
+                   status: :unprocessable_entity
+            return
+          end
+
+          current_user.update!(family: family, family_role: :family_member)
+        end
+
+        render json: { message: "ファミリーに参加しました", family_name: family.name }
+      rescue => e
+        render json: { error: "参加できませんでした" }, status: :unprocessable_entity
+      end
+
+      # POST /api/v1/family_invites/apply_code
+      def apply_code
+        raw = params[:invite_token].to_s.strip
+
+        if raw.blank?
+          render json: { error: "招待コードを入力してください" }, status: :unprocessable_entity
+          return
+        end
+
+        # URL全体添付でも末尾部分だけ抽出
+        token = raw.split("/").last
+
+        family = Family.find_by(invite_token: token)
+        unless family
+          render json: { error: "招待コードが無効です" }, status: :not_found
+          return
+        end
+
+        render json: { invite_token: family.invite_token }
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,20 @@ Rails.application.routes.draw do
 
       # 商品
       resources :products, only: [ :index ]
+
+      # ファミリー
+      get    "family",                      to: "family#show"
+      post   "family",                      to: "family#create"
+      patch  "family",                      to: "family#update"
+      delete "family",                      to: "family#destroy"
+      delete "family/leave",                to: "family#leave"
+      patch  "family/transfer_owner",       to: "family#transfer_owner"
+      post   "family/regenerate_invite",    to: "family#regenerate_invite"
+
+      # 招待
+      post "family_invites/apply_code",     to: "family_invites#apply_code"
+      get  "family_invites/:token",         to: "family_invites#show"
+      post "family_invites/:token/join",    to: "family_invites#join"
     end
   end
 

--- a/frontend/src/app/family/edit/page.tsx
+++ b/frontend/src/app/family/edit/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useFamily } from "@/hooks/useFamily";
+
+export default function FamilyEditPage() {
+  const router = useRouter();
+  const { family, isLoading, updateFamily } = useFamily();
+  const [name, setName] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (family) setName(family.name);
+  }, [family]);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      await updateFamily(name.trim());
+      router.push("/family");
+    } catch {
+      setError("更新できませんでした。もう一度お試しください。");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-orange-50 py-10 px-4">
+      <div className="max-w-md mx-auto bg-white rounded-2xl shadow border border-orange-100 p-8">
+        <h1 className="text-2xl font-bold text-center text-gray-800 mb-8">
+          グループ名を編集
+        </h1>
+
+        {error && (
+          <p className="mb-4 text-center text-red-500 text-sm font-semibold">{error}</p>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              グループ名
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              maxLength={50}
+              className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
+            />
+          </div>
+
+          <div className="flex gap-3">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="flex-1 bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white font-bold py-2.5 rounded-full shadow-md transition"
+            >
+              {submitting ? "保存中..." : "保存"}
+            </button>
+            <Link
+              href="/family"
+              className="flex-1 text-center bg-gray-100 hover:bg-gray-200 text-gray-600 font-semibold py-2.5 rounded-full transition"
+            >
+              キャンセル
+            </Link>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/family/new/page.tsx
+++ b/frontend/src/app/family/new/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useFamily } from "@/hooks/useFamily";
+
+export default function FamilyNewPage() {
+  const router = useRouter();
+  const { createFamily } = useFamily();
+  const [name, setName] = useState("ファミリー");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      await createFamily(name.trim());
+      router.push("/family");
+    } catch {
+      setError("作成できませんでした。もう一度お試しください。");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-orange-50 py-10 px-4">
+      <div className="max-w-md mx-auto bg-white rounded-2xl shadow border border-orange-100 p-8">
+        <h1 className="text-2xl font-bold text-center text-gray-800 mb-8">
+          👨‍👩‍👧 ファミリーを作成する
+        </h1>
+
+        {error && (
+          <p className="mb-4 text-center text-red-500 text-sm font-semibold">{error}</p>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              グループ名
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              maxLength={50}
+              className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white font-bold py-2.5 rounded-full shadow-md transition"
+          >
+            {submitting ? "作成中..." : "作成する"}
+          </button>
+        </form>
+
+        <Link
+          href="/settings"
+          className="block text-center text-gray-500 text-sm hover:underline mt-5"
+        >
+          ← キャンセル
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/family/page.tsx
+++ b/frontend/src/app/family/page.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useAuth } from "@/hooks/useAuth";
+import { useFamily } from "@/hooks/useFamily";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+
+export default function FamilyPage() {
+  const router = useRouter();
+  const { user, isLoading: authLoading } = useAuth();
+  const { family, isLoading, destroyFamily, leaveFamily, transferOwner, regenerateInvite } =
+    useFamily();
+
+  const [transferTargetId, setTransferTargetId] = useState<number | null>(null);
+  const [showInviteUrl, setShowInviteUrl] = useState(false);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  if (authLoading || isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (!family) {
+    return (
+      <div className="min-h-screen bg-orange-50 py-10 px-4">
+        <div className="max-w-md mx-auto text-center">
+          <p className="text-gray-500 mb-6">ファミリーに所属していません</p>
+          <Link
+            href="/family/new"
+            className="bg-orange-500 hover:bg-orange-600 text-white font-bold py-2.5 px-6 rounded-full shadow-md transition"
+          >
+            ファミリーを作成する
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const isAdmin = user?.family_role === "family_admin";
+  const inviteUrl = `${API_BASE}/family_invites/${family.invite_token}`;
+
+  async function handleRegenerate() {
+    try {
+      await regenerateInvite();
+      setActionMessage("招待リンクを再発行しました");
+      setShowInviteUrl(true);
+    } catch {
+      setErrorMessage("再発行できませんでした");
+    }
+  }
+
+  async function handleTransfer() {
+    if (!transferTargetId) return;
+    if (!confirm("管理者権限を譲渡しますか？")) return;
+    try {
+      await transferOwner(transferTargetId);
+      setActionMessage("管理者権限を譲渡しました");
+      setTransferTargetId(null);
+    } catch {
+      setErrorMessage("権限を譲渡できませんでした");
+    }
+  }
+
+  async function handleLeave() {
+    if (!confirm("ファミリーから脱退しますか？")) return;
+    try {
+      await leaveFamily();
+      router.push("/settings");
+    } catch {
+      setErrorMessage("脱退できませんでした");
+    }
+  }
+
+  async function handleDestroy() {
+    if (!confirm("ファミリーを解散しますか？この操作は取り消せません。")) return;
+    try {
+      await destroyFamily();
+      router.push("/settings");
+    } catch {
+      setErrorMessage("解散できませんでした");
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-orange-50 py-10 px-4">
+      <div className="max-w-md mx-auto space-y-4">
+        <h1 className="text-2xl font-bold text-center text-orange-500 mb-2">
+          👨‍👩‍👧 ファミリー設定
+        </h1>
+
+        {actionMessage && (
+          <p className="text-center text-green-600 text-sm font-semibold">{actionMessage}</p>
+        )}
+        {errorMessage && (
+          <p className="text-center text-red-500 text-sm font-semibold">{errorMessage}</p>
+        )}
+
+        {/* ファミリー情報 */}
+        <div className="bg-white rounded-2xl shadow border border-orange-100 p-5">
+          <div className="flex justify-between items-center mb-1">
+            <p className="text-sm text-gray-500">グループ名</p>
+            {isAdmin && (
+              <Link href="/family/edit" className="text-xs text-orange-500 hover:underline">
+                編集
+              </Link>
+            )}
+          </div>
+          <p className="font-bold text-gray-800 text-lg">{family.name}</p>
+          <p className="text-sm text-gray-500 mt-3">
+            メンバー {family.members_count} 人 / 最大 3 人
+          </p>
+        </div>
+
+        {/* メンバー一覧 */}
+        <div className="bg-white rounded-2xl shadow border border-orange-100 overflow-hidden">
+          <p className="px-5 pt-4 pb-2 text-sm font-semibold text-gray-600">メンバー</p>
+          {family.members.map((member) => (
+            <div
+              key={member.id}
+              className="flex justify-between items-center px-5 py-3 border-t border-gray-100"
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-gray-800">{member.nickname ?? "名前未設定"}</span>
+                {member.family_role === "family_admin" && (
+                  <span className="text-xs bg-orange-100 text-orange-600 px-2 py-0.5 rounded">
+                    管理者
+                  </span>
+                )}
+              </div>
+              {isAdmin && member.id !== user?.id && (
+                <button
+                  type="button"
+                  onClick={() => setTransferTargetId(member.id)}
+                  className="text-xs text-orange-500 hover:underline"
+                >
+                  権限を渡す
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* 権限譲渡確認 */}
+        {transferTargetId && (
+          <div className="bg-orange-50 border border-orange-200 rounded-2xl p-4 text-center">
+            <p className="text-sm text-gray-700 mb-3">
+              {family.members.find((m) => m.id === transferTargetId)?.nickname} さんに管理者権限を譲渡しますか？
+            </p>
+            <div className="flex gap-3 justify-center">
+              <button
+                type="button"
+                onClick={handleTransfer}
+                className="bg-orange-500 text-white px-4 py-1.5 rounded-full text-sm font-semibold hover:bg-orange-600 transition"
+              >
+                譲渡する
+              </button>
+              <button
+                type="button"
+                onClick={() => setTransferTargetId(null)}
+                className="bg-gray-100 text-gray-600 px-4 py-1.5 rounded-full text-sm hover:bg-gray-200 transition"
+              >
+                キャンセル
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* 招待リンク */}
+        {isAdmin && (
+          <div className="bg-white rounded-2xl shadow border border-orange-100 p-5">
+            <p className="text-sm font-semibold text-gray-600 mb-3">招待リンク</p>
+            <button
+              type="button"
+              onClick={() => setShowInviteUrl(!showInviteUrl)}
+              className="text-sm text-orange-500 hover:underline mb-2 block"
+            >
+              {showInviteUrl ? "非表示" : "招待リンクを表示"}
+            </button>
+            {showInviteUrl && (
+              <div className="bg-gray-50 rounded-xl p-3 break-all text-xs text-gray-600 mb-3">
+                {inviteUrl}
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={handleRegenerate}
+              className="text-xs text-gray-500 hover:underline"
+            >
+              招待リンクを再発行する
+            </button>
+          </div>
+        )}
+
+        {/* 招待コード入力で参加 */}
+        {!isAdmin && (
+          <Link
+            href="/family_invites/enter_code"
+            className="block w-full text-center bg-orange-100 hover:bg-orange-200 text-orange-600 font-semibold py-3 rounded-2xl border border-orange-200 transition text-sm"
+          >
+            招待コードで参加する
+          </Link>
+        )}
+
+        {/* 脱退・解散 */}
+        <div className="space-y-2 pt-2">
+          {!isAdmin && (
+            <button
+              type="button"
+              onClick={handleLeave}
+              className="block w-full text-center text-red-500 hover:text-red-600 font-semibold py-3 rounded-2xl border border-red-200 hover:bg-red-50 transition text-sm"
+            >
+              ファミリーから脱退する
+            </button>
+          )}
+          {isAdmin && (
+            <button
+              type="button"
+              onClick={handleDestroy}
+              className="block w-full text-center text-red-500 hover:text-red-600 font-semibold py-3 rounded-2xl border border-red-200 hover:bg-red-50 transition text-sm"
+            >
+              ファミリーを解散する
+            </button>
+          )}
+        </div>
+
+        <Link
+          href="/settings"
+          className="block text-center text-gray-500 text-sm hover:underline pt-2"
+        >
+          ← 設定に戻る
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/family_invites/[token]/page.tsx
+++ b/frontend/src/app/family_invites/[token]/page.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { use, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/hooks/useAuth";
+import { apiFetch } from "@/lib/api";
+import type { FamilyInviteInfo } from "@/types";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+
+export default function FamilyInvitePage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = use(params);
+  const router = useRouter();
+  const { user, isLoading: authLoading } = useAuth();
+  const [inviteInfo, setInviteInfo] = useState<FamilyInviteInfo | null>(null);
+  const [infoLoading, setInfoLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [joining, setJoining] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/api/v1/family_invites/${token}`, { credentials: "include" })
+      .then(async (res) => {
+        if (!res.ok) { setNotFound(true); return; }
+        setInviteInfo(await res.json());
+      })
+      .catch(() => setNotFound(true))
+      .finally(() => setInfoLoading(false));
+  }, [token]);
+
+  async function handleJoin() {
+    if (!user) {
+      /* 未ログインならログイン後に戻ってくるよう誘導 */
+      window.location.href = `${API_BASE}/users/sign_in`;
+      return;
+    }
+    setJoining(true);
+    setError(null);
+    try {
+      await apiFetch(`/api/v1/family_invites/${token}/join`, { method: "POST" });
+      router.push("/family");
+    } catch {
+      setError("参加できませんでした。すでに別のファミリーに所属しているか、上限に達している可能性があります。");
+    } finally {
+      setJoining(false);
+    }
+  }
+
+  if (authLoading || infoLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <div className="min-h-screen bg-orange-50 flex items-center justify-center px-4">
+        <div className="bg-white rounded-2xl shadow border border-orange-100 p-8 text-center max-w-sm w-full">
+          <p className="text-gray-700 mb-4">招待リンクが無効です。</p>
+          <a href="/" className="text-orange-500 hover:underline text-sm">
+            ホームへ戻る
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-orange-50 flex items-center justify-center px-4">
+      <div className="bg-white rounded-2xl shadow border border-orange-100 p-8 text-center max-w-sm w-full">
+        <h1 className="text-xl font-bold text-gray-800 mb-2">ファミリーへの招待</h1>
+        <p className="text-2xl font-bold text-orange-500 mb-1">{inviteInfo?.name}</p>
+        <p className="text-sm text-gray-500 mb-6">
+          現在 {inviteInfo?.members_count} 人 / 残り {inviteInfo?.remaining_slots} 人参加可能
+        </p>
+
+        {error && (
+          <p className="mb-4 text-red-500 text-sm font-semibold">{error}</p>
+        )}
+
+        {inviteInfo && inviteInfo.remaining_slots > 0 ? (
+          <button
+            type="button"
+            onClick={handleJoin}
+            disabled={joining}
+            className="w-full bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white font-bold py-2.5 rounded-full shadow-md transition"
+          >
+            {joining ? "参加中..." : user ? "ファミリーに参加する" : "ログインして参加する"}
+          </button>
+        ) : (
+          <p className="text-gray-500 text-sm">このファミリーは満員です。</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/family_invites/enter_code/page.tsx
+++ b/frontend/src/app/family_invites/enter_code/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+
+export default function EnterCodePage() {
+  const router = useRouter();
+  const [code, setCode] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await apiFetch<{ invite_token: string }>(
+        "/api/v1/family_invites/apply_code",
+        {
+          method: "POST",
+          body: JSON.stringify({ invite_token: code.trim() }),
+        }
+      );
+      router.push(`/family_invites/${result.invite_token}`);
+    } catch {
+      setError("招待コードが無効です。もう一度確認してください。");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-orange-50 py-10 px-4">
+      <div className="max-w-md mx-auto bg-white rounded-2xl shadow border border-orange-100 p-8">
+        <h1 className="text-2xl font-bold text-center text-gray-800 mb-2">
+          招待コードで参加
+        </h1>
+        <p className="text-center text-sm text-gray-500 mb-8">
+          招待リンクまたは招待コードを貼り付けてください
+        </p>
+
+        {error && (
+          <p className="mb-4 text-center text-red-500 text-sm font-semibold">{error}</p>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              招待コード / 招待リンク
+            </label>
+            <input
+              type="text"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              required
+              placeholder="招待コードまたはURLを入力"
+              className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={submitting || !code.trim()}
+            className="w-full bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white font-bold py-2.5 rounded-full shadow-md transition"
+          >
+            {submitting ? "確認中..." : "確認する"}
+          </button>
+        </form>
+
+        <Link
+          href="/family"
+          className="block text-center text-gray-500 text-sm hover:underline mt-5"
+        >
+          ← キャンセル
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useFamily.ts
+++ b/frontend/src/hooks/useFamily.ts
@@ -1,0 +1,75 @@
+import useSWR from "swr";
+import { apiFetch } from "@/lib/api";
+import type { Family } from "@/types";
+
+/** ファミリー情報の取得・操作フック */
+export function useFamily() {
+  const { data, error, isLoading, mutate } = useSWR<Family>(
+    "/api/v1/family",
+    (path: string) => apiFetch<Family>(path),
+    { shouldRetryOnError: false }
+  );
+
+  /** ファミリー作成 */
+  async function createFamily(name: string): Promise<Family> {
+    const created = await apiFetch<Family>("/api/v1/family", {
+      method: "POST",
+      body: JSON.stringify({ family: { name } }),
+    });
+    mutate(created, false);
+    return created;
+  }
+
+  /** ファミリー名更新 */
+  async function updateFamily(name: string): Promise<Family> {
+    const updated = await apiFetch<Family>("/api/v1/family", {
+      method: "PATCH",
+      body: JSON.stringify({ family: { name } }),
+    });
+    mutate(updated, false);
+    return updated;
+  }
+
+  /** ファミリー解散 */
+  async function destroyFamily(): Promise<void> {
+    await apiFetch("/api/v1/family", { method: "DELETE" });
+    mutate(undefined, false);
+  }
+
+  /** ファミリー脱退 */
+  async function leaveFamily(): Promise<void> {
+    await apiFetch("/api/v1/family/leave", { method: "DELETE" });
+    mutate(undefined, false);
+  }
+
+  /** 管理者権限を別メンバーに譲渡 */
+  async function transferOwner(memberId: number): Promise<Family> {
+    const updated = await apiFetch<Family>("/api/v1/family/transfer_owner", {
+      method: "PATCH",
+      body: JSON.stringify({ member_id: memberId }),
+    });
+    mutate(updated, false);
+    return updated;
+  }
+
+  /** 招待トークン再発行 */
+  async function regenerateInvite(): Promise<Family> {
+    const updated = await apiFetch<Family>("/api/v1/family/regenerate_invite", {
+      method: "POST",
+    });
+    mutate(updated, false);
+    return updated;
+  }
+
+  return {
+    family: data,
+    isLoading,
+    error,
+    createFamily,
+    updateFamily,
+    destroyFamily,
+    leaveFamily,
+    transferOwner,
+    regenerateInvite,
+  };
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -55,6 +55,29 @@ export type PriceRecordFormData = {
   products: { id: number; public_id: string; name: string; category_id: number | null }[];
 };
 
+/** ファミリーメンバー */
+export type FamilyMember = {
+  id: number;
+  nickname: string | null;
+  family_role: "family_admin" | "family_member";
+};
+
+/** ファミリー情報 */
+export type Family = {
+  id: number;
+  name: string;
+  invite_token: string;
+  members_count: number;
+  members: FamilyMember[];
+};
+
+/** 招待情報（未ログインでも取得可能） */
+export type FamilyInviteInfo = {
+  name: string;
+  members_count: number;
+  remaining_slots: number;
+};
+
 /** 商品 */
 export type Product = {
   id: number;

--- a/frontend/tests/hooks/useFamily.test.ts
+++ b/frontend/tests/hooks/useFamily.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useFamily } from "@/hooks/useFamily";
+
+vi.mock("swr");
+vi.mock("@/lib/api");
+
+describe("useFamily", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("ファミリー情報を返す", async () => {
+    const useSWR = (await import("swr")).default;
+    const mockFamily = {
+      id: 1,
+      name: "テストファミリー",
+      invite_token: "abc123",
+      members_count: 2,
+      members: [
+        { id: 1, nickname: "管理者", family_role: "family_admin" },
+        { id: 2, nickname: "メンバー", family_role: "family_member" },
+      ],
+    };
+    vi.mocked(useSWR).mockReturnValue({
+      data: mockFamily,
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as ReturnType<typeof useSWR>);
+
+    const { result } = renderHook(() => useFamily());
+    expect(result.current.family).toEqual(mockFamily);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("createFamily を呼ぶと POST が実行される", async () => {
+    const useSWR = (await import("swr")).default;
+    const mutateMock = vi.fn();
+    vi.mocked(useSWR).mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+      mutate: mutateMock,
+    } as ReturnType<typeof useSWR>);
+
+    const { apiFetch } = await import("@/lib/api");
+    vi.mocked(apiFetch).mockResolvedValue({ id: 1, name: "新ファミリー" });
+
+    const { result } = renderHook(() => useFamily());
+
+    await act(async () => {
+      await result.current.createFamily("新ファミリー");
+    });
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/family", {
+      method: "POST",
+      body: JSON.stringify({ family: { name: "新ファミリー" } }),
+    });
+  });
+
+  it("updateFamily を呼ぶと PATCH が実行される", async () => {
+    const useSWR = (await import("swr")).default;
+    const mutateMock = vi.fn();
+    vi.mocked(useSWR).mockReturnValue({
+      data: { id: 1, name: "旧名前" },
+      error: undefined,
+      isLoading: false,
+      mutate: mutateMock,
+    } as ReturnType<typeof useSWR>);
+
+    const { apiFetch } = await import("@/lib/api");
+    vi.mocked(apiFetch).mockResolvedValue({ id: 1, name: "新名前" });
+
+    const { result } = renderHook(() => useFamily());
+
+    await act(async () => {
+      await result.current.updateFamily("新名前");
+    });
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/family", {
+      method: "PATCH",
+      body: JSON.stringify({ family: { name: "新名前" } }),
+    });
+  });
+
+  it("regenerateInvite を呼ぶと POST が実行される", async () => {
+    const useSWR = (await import("swr")).default;
+    const mutateMock = vi.fn();
+    vi.mocked(useSWR).mockReturnValue({
+      data: { id: 1, invite_token: "old_token" },
+      error: undefined,
+      isLoading: false,
+      mutate: mutateMock,
+    } as ReturnType<typeof useSWR>);
+
+    const { apiFetch } = await import("@/lib/api");
+    vi.mocked(apiFetch).mockResolvedValue({ id: 1, invite_token: "new_token" });
+
+    const { result } = renderHook(() => useFamily());
+
+    await act(async () => {
+      await result.current.regenerateInvite();
+    });
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/family/regenerate_invite", {
+      method: "POST",
+    });
+  });
+});

--- a/spec/requests/api/v1/family_invites_spec.rb
+++ b/spec/requests/api/v1/family_invites_spec.rb
@@ -1,0 +1,123 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::FamilyInvites", type: :request do
+  let(:admin_user) { create(:user, :without_callbacks) }
+  let(:personal_user) { create(:user, :without_callbacks, :personal) }
+  let(:family) do
+    fam = create(:family, owner: admin_user)
+    admin_user.update!(family: fam, family_role: :family_admin)
+    fam
+  end
+
+  before { family }
+
+  describe "GET /api/v1/family_invites/:token" do
+    it "有効なトークンでファミリー情報を返す" do
+      get "/api/v1/family_invites/#{family.invite_token}"
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["name"]).to eq(family.name)
+      expect(json["members_count"]).to eq(family.users.count)
+    end
+
+    it "無効なトークンで404を返す" do
+      get "/api/v1/family_invites/invalid_token"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "POST /api/v1/family_invites/:token/join" do
+    context "personalユーザーでログイン中" do
+      before { sign_in(personal_user, scope: :user) }
+
+      it "ファミリーに参加できる" do
+        post "/api/v1/family_invites/#{family.invite_token}/join"
+        expect(response).to have_http_status(:ok)
+        expect(personal_user.reload.family_member?).to be true
+        expect(personal_user.reload.family).to eq(family)
+      end
+    end
+
+    context "すでに別ファミリーに所属している場合（管理者）" do
+      before { sign_in(admin_user, scope: :user) }
+
+      it "422を返す" do
+        post "/api/v1/family_invites/#{family.invite_token}/join"
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "上限（3名）に達している場合" do
+      before do
+        # admin + 2名追加して上限に
+        2.times do
+          u = create(:user, :without_callbacks)
+          u.update!(family: family, family_role: :family_member)
+        end
+        sign_in(personal_user, scope: :user)
+      end
+
+      it "422を返す" do
+        post "/api/v1/family_invites/#{family.invite_token}/join"
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "未認証" do
+      it "401を返す" do
+        post "/api/v1/family_invites/#{family.invite_token}/join"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "無効なトークン" do
+      before { sign_in(personal_user, scope: :user) }
+
+      it "404を返す" do
+        post "/api/v1/family_invites/invalid_token/join"
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "POST /api/v1/family_invites/apply_code" do
+    context "ログイン中" do
+      before { sign_in(personal_user, scope: :user) }
+
+      it "有効なコードでトークンを返す" do
+        post "/api/v1/family_invites/apply_code",
+             params: { invite_token: family.invite_token }
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json["invite_token"]).to eq(family.invite_token)
+      end
+
+      it "URL形式でも末尾トークンを抽出してOK" do
+        post "/api/v1/family_invites/apply_code",
+             params: { invite_token: "https://example.com/family_invites/#{family.invite_token}" }
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json["invite_token"]).to eq(family.invite_token)
+      end
+
+      it "無効なコードで404を返す" do
+        post "/api/v1/family_invites/apply_code",
+             params: { invite_token: "invalid_code" }
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "空のコードで422を返す" do
+        post "/api/v1/family_invites/apply_code", params: { invite_token: "" }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "未認証" do
+      it "401を返す" do
+        post "/api/v1/family_invites/apply_code",
+             params: { invite_token: family.invite_token }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/family_spec.rb
+++ b/spec/requests/api/v1/family_spec.rb
@@ -1,0 +1,214 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Family", type: :request do
+  let(:admin_user) { create(:user, :without_callbacks) }
+  let(:member_user) { create(:user, :without_callbacks) }
+  let(:other_user)  { create(:user, :without_callbacks) }
+  let(:family) do
+    fam = create(:family, owner: admin_user)
+    admin_user.update!(family: fam, family_role: :family_admin)
+    fam
+  end
+
+  before { family }
+
+  describe "GET /api/v1/family" do
+    context "管理者でログイン中" do
+      before { sign_in(admin_user, scope: :user) }
+
+      it "ファミリー情報とメンバー一覧をJSONで返す" do
+        get "/api/v1/family"
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json["id"]).to eq(family.id)
+        expect(json["name"]).to eq(family.name)
+        expect(json["invite_token"]).to eq(family.invite_token)
+        expect(json["members"]).to be_an(Array)
+        expect(json["members"].first["id"]).to eq(admin_user.id)
+        expect(json["members"].first["family_role"]).to eq("family_admin")
+      end
+    end
+
+    context "personalユーザーでログイン中" do
+      let(:personal) { create(:user, :without_callbacks, :personal) }
+      before { sign_in(personal, scope: :user) }
+
+      it "404を返す" do
+        get "/api/v1/family"
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "未認証" do
+      it "401を返す" do
+        get "/api/v1/family"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "POST /api/v1/family" do
+    context "personalユーザーでログイン中" do
+      let(:personal) { create(:user, :without_callbacks, :personal) }
+      before { sign_in(personal, scope: :user) }
+
+      it "ファミリーを作成して管理者になる" do
+        expect {
+          post "/api/v1/family", params: { family: { name: "テストファミリー" } }
+        }.to change(Family, :count).by(1)
+        expect(response).to have_http_status(:created)
+        json = JSON.parse(response.body)
+        expect(json["name"]).to eq("テストファミリー")
+        expect(personal.reload.family_admin?).to be true
+      end
+    end
+
+    context "すでにファミリーに所属している場合" do
+      before { sign_in(admin_user, scope: :user) }
+
+      it "422を返す" do
+        post "/api/v1/family", params: { family: { name: "別ファミリー" } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "未認証" do
+      it "401を返す" do
+        post "/api/v1/family", params: { family: { name: "テスト" } }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "PATCH /api/v1/family" do
+    context "管理者でログイン中" do
+      before { sign_in(admin_user, scope: :user) }
+
+      it "ファミリー名を更新できる" do
+        patch "/api/v1/family", params: { family: { name: "新しい名前" } }
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)["name"]).to eq("新しい名前")
+        expect(family.reload.name).to eq("新しい名前")
+      end
+    end
+
+    context "一般メンバーでログイン中" do
+      before do
+        member_user.update!(family: family, family_role: :family_member)
+        sign_in(member_user, scope: :user)
+      end
+
+      it "403を返す" do
+        patch "/api/v1/family", params: { family: { name: "変更試み" } }
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/family" do
+    context "管理者でログイン中" do
+      before { sign_in(admin_user, scope: :user) }
+
+      it "ファミリーを解散して全員personalに戻る" do
+        expect {
+          delete "/api/v1/family"
+        }.to change(Family, :count).by(-1)
+        expect(response).to have_http_status(:ok)
+        expect(admin_user.reload.personal?).to be true
+      end
+    end
+
+    context "一般メンバーでログイン中" do
+      before do
+        member_user.update!(family: family, family_role: :family_member)
+        sign_in(member_user, scope: :user)
+      end
+
+      it "403を返す" do
+        delete "/api/v1/family"
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/family/leave" do
+    context "一般メンバーでログイン中" do
+      before do
+        member_user.update!(family: family, family_role: :family_member)
+        sign_in(member_user, scope: :user)
+      end
+
+      it "ファミリーから脱退してpersonalになる" do
+        delete "/api/v1/family/leave"
+        expect(response).to have_http_status(:ok)
+        expect(member_user.reload.personal?).to be true
+      end
+    end
+
+    context "管理者でログイン中" do
+      before { sign_in(admin_user, scope: :user) }
+
+      it "422を返す（権限譲渡が先に必要）" do
+        delete "/api/v1/family/leave"
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "PATCH /api/v1/family/transfer_owner" do
+    before do
+      member_user.update!(family: family, family_role: :family_member)
+    end
+
+    context "管理者でログイン中" do
+      before { sign_in(admin_user, scope: :user) }
+
+      it "別メンバーに管理者権限を譲渡できる" do
+        patch "/api/v1/family/transfer_owner", params: { member_id: member_user.id }
+        expect(response).to have_http_status(:ok)
+        expect(member_user.reload.family_admin?).to be true
+        expect(admin_user.reload.family_member?).to be true
+        expect(family.reload.owner).to eq(member_user)
+      end
+
+      it "存在しないメンバーIDには404を返す" do
+        patch "/api/v1/family/transfer_owner", params: { member_id: 999999 }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "一般メンバーでログイン中" do
+      before { sign_in(member_user, scope: :user) }
+
+      it "403を返す" do
+        patch "/api/v1/family/transfer_owner", params: { member_id: admin_user.id }
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "POST /api/v1/family/regenerate_invite" do
+    context "管理者でログイン中" do
+      before { sign_in(admin_user, scope: :user) }
+
+      it "招待トークンを再発行できる" do
+        old_token = family.invite_token
+        post "/api/v1/family/regenerate_invite"
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)["invite_token"]).not_to eq(old_token)
+      end
+    end
+
+    context "一般メンバーでログイン中" do
+      before do
+        member_user.update!(family: family, family_role: :family_member)
+        sign_in(member_user, scope: :user)
+      end
+
+      it "403を返す" do
+        post "/api/v1/family/regenerate_invite"
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

ファミリー機能の画面・API を Next.js へ移行した。Rails の `FamiliesController` / `FamilyInvitesController` を JSON API 化し、Next.js で対応する5画面を実装。

## 変更内容

### Rails（JSON API 追加）
- `GET /api/v1/family` — ファミリー情報・メンバー一覧取得
- `POST /api/v1/family` — ファミリー作成（実行者が管理者になる）
- `PATCH /api/v1/family` — グループ名更新（管理者のみ）
- `DELETE /api/v1/family` — ファミリー解散（管理者のみ）
- `DELETE /api/v1/family/leave` — ファミリー脱退（メンバーのみ、管理者は権限譲渡が先）
- `PATCH /api/v1/family/transfer_owner` — 管理者権限譲渡（管理者のみ）
- `POST /api/v1/family/regenerate_invite` — 招待トークン再発行（管理者のみ）
- `GET /api/v1/family_invites/:token` — 招待情報確認（**認証不要**）
- `POST /api/v1/family_invites/:token/join` — 招待リンクから参加
- `POST /api/v1/family_invites/apply_code` — 招待コード検証

### Next.js（新規画面）
| 画面 | URL |
|---|---|
| ファミリー詳細 | `/family` |
| ファミリー作成 | `/family/new` |
| グループ名編集 | `/family/edit` |
| 招待参加確認 | `/family_invites/[token]` |
| 招待コード入力 | `/family_invites/enter_code` |

### 新規フック・型定義
- `src/hooks/useFamily.ts`（SWR + 操作関数）
- `src/types/index.ts` に `Family` / `FamilyMember` / `FamilyInviteInfo` 型を追加

## 対象ファイル

- `app/controllers/api/v1/family_controller.rb`（新規）
- `app/controllers/api/v1/family_invites_controller.rb`（新規）
- `config/routes.rb`（api/v1 名前空間に追加）
- `spec/requests/api/v1/family_spec.rb`（新規）
- `spec/requests/api/v1/family_invites_spec.rb`（新規）
- `frontend/src/types/index.ts`（型追加）
- `frontend/src/hooks/useFamily.ts`（新規）
- `frontend/src/app/family/page.tsx`（新規）
- `frontend/src/app/family/new/page.tsx`（新規）
- `frontend/src/app/family/edit/page.tsx`（新規）
- `frontend/src/app/family_invites/[token]/page.tsx`（新規）
- `frontend/src/app/family_invites/enter_code/page.tsx`（新規）
- `frontend/tests/hooks/useFamily.test.ts`（新規）

## 受入テスト項目

- [ ] personal ユーザーが `/family/new` からファミリーを作成でき、管理者として `/family` に遷移する
- [ ] メンバー一覧・招待リンクが `/family` に表示される
- [ ] 招待リンクを別ユーザーが踏むと `/family_invites/[token]` で参加確認画面が表示される
- [ ] 招待コード入力（`/family_invites/enter_code`）でも同様に参加できる
- [ ] 上限（3名）超えは参加できず適切なエラーが表示される
- [ ] 管理者が別メンバーに権限を譲渡できる
- [ ] メンバーが脱退できる（管理者は権限譲渡後のみ）
- [ ] 管理者がファミリーを解散でき、全員が personal に戻る
- [ ] `/family/edit` でグループ名を変更できる（管理者のみ）

## 影響範囲

- `/settings` の「ファミリー設定」リンクは既実装済みで、本PRの `/family` に繋がる
- iOS WebView はこれらの URL をそのまま表示するため変更不要

## 確認手順

```bash
# Rails テスト
bundle exec rspec spec/requests/api/v1/family_spec.rb spec/requests/api/v1/family_invites_spec.rb

# Next.js テスト
cd frontend && npm test
```

## その他

- 招待情報確認 API（`GET /api/v1/family_invites/:token`）は未ログインでも家族名・残席を表示するため認証不要
- RSpec 29例・Vitest 23例（うち今回追加4例）すべてグリーン

Closes #202