### PR TITLE
Phase 3-7: 管理画面 Next.js 移行

### DIFF
--- a/app/controllers/api/v1/admin/abnormal_prices_controller.rb
+++ b/app/controllers/api/v1/admin/abnormal_prices_controller.rb
@@ -1,0 +1,29 @@
+module Api
+  module V1
+    module Admin
+      class AbnormalPricesController < BaseController
+        include AbnormalPriceDetector
+
+        def index
+          abnormal = find_abnormal_price_records(full: true)
+
+          records = abnormal.map do |item|
+            pr = item[:record]
+            {
+              id: pr.id,
+              price: pr.price,
+              avg_price: item[:avg_price],
+              deviation: item[:deviation],
+              product_name: pr.product&.name,
+              shop_name: pr.shop&.name,
+              user_nickname: pr.user&.nickname,
+              purchased_at: pr.purchased_at
+            }
+          end
+
+          render json: records
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/base_controller.rb
+++ b/app/controllers/api/v1/admin/base_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V1
+    module Admin
+      class BaseController < Api::V1::BaseController
+        before_action :require_admin!
+
+        private
+
+        def require_admin!
+          unless current_user&.admin?
+            render json: { error: "権限がありません" }, status: :forbidden
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/contacts_controller.rb
+++ b/app/controllers/api/v1/admin/contacts_controller.rb
@@ -1,0 +1,61 @@
+module Api
+  module V1
+    module Admin
+      class ContactsController < BaseController
+        before_action :set_contact, only: [ :show, :update ]
+
+        def index
+          contacts = Contact.order(created_at: :desc)
+
+          if params[:status].present?
+            contacts = contacts.where(status: params[:status])
+          end
+
+          total    = contacts.count
+          page     = (params[:page] || 1).to_i
+          per      = 20
+          contacts = contacts.offset((page - 1) * per).limit(per)
+
+          render json: {
+            contacts: contacts.map { |c| contact_json(c) },
+            meta: { total: total, page: page, per: per }
+          }
+        end
+
+        def show
+          render json: contact_json(@contact)
+        end
+
+        def update
+          if @contact.update(contact_params)
+            render json: contact_json(@contact)
+          else
+            render json: { errors: @contact.errors.full_messages }, status: :unprocessable_entity
+          end
+        end
+
+        private
+
+        def set_contact
+          @contact = Contact.find(params[:id])
+        end
+
+        def contact_params
+          params.require(:contact).permit(:status, :admin_memo)
+        end
+
+        def contact_json(contact)
+          {
+            id: contact.id,
+            nickname: contact.nickname,
+            email: contact.email,
+            body: contact.body,
+            status: contact.status,
+            admin_memo: contact.admin_memo,
+            created_at: contact.created_at
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/dashboards_controller.rb
+++ b/app/controllers/api/v1/admin/dashboards_controller.rb
@@ -1,0 +1,53 @@
+module Api
+  module V1
+    module Admin
+      class DashboardsController < BaseController
+        def index
+          today_start     = Time.zone.today.beginning_of_day
+          yesterday_start = Time.zone.yesterday.beginning_of_day
+
+          new_users_today     = User.where("created_at >= ?", today_start).count
+          new_users_yesterday = User.where(created_at: yesterday_start...today_start).count
+
+          current_30d_start  = 30.days.ago.beginning_of_day
+          previous_30d_start = 60.days.ago.beginning_of_day
+
+          new_users_30d      = User.where("created_at >= ?", current_30d_start).count
+          new_users_prev_30d = User.where(created_at: previous_30d_start...current_30d_start).count
+
+          unresolved_contacts = Contact.where(status: "unread").count rescue 0
+
+          top_products = Product
+            .joins(:price_records)
+            .group("products.name")
+            .order("COUNT(price_records.id) DESC")
+            .limit(5)
+            .count
+            .map { |name, count| { name: name, records_count: count } }
+
+          top_shops = Shop
+            .joins(:price_records)
+            .group("shops.name")
+            .order("COUNT(price_records.id) DESC")
+            .limit(5)
+            .count
+            .map { |name, count| { name: name, records_count: count } }
+
+          render json: {
+            new_users_today: new_users_today,
+            new_users_yesterday: new_users_yesterday,
+            new_users_diff: new_users_today - new_users_yesterday,
+            active_users: User.where("last_sign_in_at > ?", 30.days.ago).count,
+            new_users_30d: new_users_30d,
+            new_users_prev_30d: new_users_prev_30d,
+            new_users_30d_diff: new_users_30d - new_users_prev_30d,
+            total_families: Family.count,
+            unresolved_contacts: unresolved_contacts,
+            top_products: top_products,
+            top_shops: top_shops
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/families_controller.rb
+++ b/app/controllers/api/v1/admin/families_controller.rb
@@ -1,0 +1,83 @@
+module Api
+  module V1
+    module Admin
+      class FamiliesController < BaseController
+        before_action :set_family, only: [ :show, :change_admin, :remove_member ]
+
+        def index
+          families = Family.includes(:users).order(created_at: :desc)
+          total    = families.count
+          page     = (params[:page] || 1).to_i
+          per      = 20
+          families = families.offset((page - 1) * per).limit(per)
+
+          render json: {
+            families: families.map { |f| family_summary_json(f) },
+            meta: { total: total, page: page, per: per }
+          }
+        end
+
+        def show
+          render json: family_detail_json(@family)
+        end
+
+        def change_admin
+          new_admin = @family.users.find(params[:user_id])
+
+          Family.transaction do
+            @family.users.where(family_role: :family_admin)
+                   .update_all(family_role: User.family_roles[:family_member])
+            new_admin.update!(family_role: :family_admin)
+            @family.update!(owner: new_admin)
+          end
+
+          render json: family_detail_json(@family.reload)
+        rescue ActiveRecord::RecordNotFound
+          render json: { error: "メンバーが見つかりません" }, status: :not_found
+        end
+
+        def remove_member
+          user = User.find(params[:user_id])
+          user.update!(family_id: nil, family_role: :personal)
+          render json: { message: "#{user.nickname} さんをファミリーから除名しました" }
+        rescue ActiveRecord::RecordNotFound
+          render json: { error: "ユーザーが見つかりません" }, status: :not_found
+        end
+
+        private
+
+        def set_family
+          @family = Family.find(params[:id])
+        end
+
+        def family_summary_json(family)
+          {
+            id: family.id,
+            name: family.name,
+            members_count: family.users.size,
+            created_at: family.created_at
+          }
+        end
+
+        def family_detail_json(family)
+          {
+            id: family.id,
+            name: family.name,
+            invite_token: family.invite_token,
+            members_count: family.users.count,
+            created_at: family.created_at,
+            members: family.users.order(created_at: :asc).map { |u|
+              {
+                id: u.id,
+                nickname: u.nickname,
+                email: u.email,
+                family_role: u.family_role,
+                created_at: u.created_at
+              }
+            }
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/services_controller.rb
+++ b/app/controllers/api/v1/admin/services_controller.rb
@@ -1,0 +1,27 @@
+module Api
+  module V1
+    module Admin
+      class ServicesController < BaseController
+        def index
+          from = 30.days.ago
+          active_users_count = PriceRecord.where("created_at >= ?", from).select(:user_id).distinct.count
+
+          render json: {
+            users_count: User.count,
+            products_count: Product.count,
+            price_records_count: PriceRecord.count,
+            shops_count: Shop.count,
+            families_count: Family.count,
+            active_users_count: active_users_count,
+            avg_records_per_user: active_users_count.zero? ? 0 :
+              (PriceRecord.where("created_at >= ?", from).count / active_users_count.to_f).round(1),
+            rails_version: Rails.version,
+            ruby_version: RUBY_VERSION,
+            env: Rails.env,
+            db_connected: ActiveRecord::Base.connection.active?
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/stats_controller.rb
+++ b/app/controllers/api/v1/admin/stats_controller.rb
@@ -1,0 +1,62 @@
+module Api
+  module V1
+    module Admin
+      class StatsController < BaseController
+        def index
+          keyword   = params[:keyword]
+          shop_name = params[:shop_name]
+          pref      = params[:pref]
+
+          records = PriceRecord.joins(:product, :shop)
+
+          records = records.where("products.name LIKE ?", "%#{keyword}%") if keyword.present?
+          records = records.where("shops.name LIKE ?", "%#{shop_name}%") if shop_name.present?
+          if pref.present?
+            records = records.joins(product: :user).where(users: { prefecture: pref })
+          end
+
+          count = records.count
+
+          top_products_by_records = Product
+            .joins(:price_records)
+            .group(:name)
+            .order("COUNT(price_records.id) DESC")
+            .limit(5)
+            .count
+            .map { |name, c| { name: name, count: c } }
+
+          top_shops = Shop
+            .joins(:price_records)
+            .group(:name)
+            .order("COUNT(price_records.id) DESC")
+            .limit(5)
+            .count
+            .map { |name, c| { name: name, count: c } }
+
+          render json: {
+            count: count,
+            min_price: count.zero? ? nil : records.minimum(:price),
+            max_price: count.zero? ? nil : records.maximum(:price),
+            avg_price: count.zero? ? nil : records.average(:price)&.to_f&.round(1),
+            top_products_by_records: top_products_by_records,
+            top_shops: top_shops
+          }
+        end
+
+        def autocomplete_products
+          keyword  = params[:q].to_s.strip
+          products = keyword.present? ? Product.where("name LIKE ?", "%#{keyword}%")
+                                                .group(:name).order(Arel.sql("COUNT(*) DESC")).limit(10).pluck(:name) : []
+          render json: products
+        end
+
+        def autocomplete_shops
+          keyword = params[:q].to_s.strip
+          shops   = keyword.present? ? Shop.where("name LIKE ?", "%#{keyword}%")
+                                           .group(:name).order(Arel.sql("COUNT(*) DESC")).limit(10).pluck(:name) : []
+          render json: shops
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -1,0 +1,95 @@
+module Api
+  module V1
+    module Admin
+      class UsersController < BaseController
+        before_action :set_user, only: [ :show, :update, :ban, :unban ]
+
+        def index
+          users = User.order(created_at: :desc)
+
+          # キーワード検索（メール・ニックネーム）
+          if params[:q].present?
+            q = "%#{params[:q]}%"
+            users = users.where("email LIKE ? OR nickname LIKE ?", q, q)
+          end
+
+          total = users.count
+          page  = (params[:page] || 1).to_i
+          per   = 20
+          users = users.offset((page - 1) * per).limit(per)
+
+          render json: {
+            users: users.map { |u| user_json(u) },
+            meta: { total: total, page: page, per: per }
+          }
+        end
+
+        def show
+          render json: user_json(@user, detail: true)
+        end
+
+        def update
+          if @user.update(params.require(:user).permit(:admin_memo))
+            render json: user_json(@user)
+          else
+            render json: { errors: @user.errors.full_messages }, status: :unprocessable_entity
+          end
+        end
+
+        def ban
+          @user.update!(status: "banned", banned_reason: params[:reason])
+          render json: user_json(@user)
+        end
+
+        def unban
+          @user.update!(status: "active", banned_reason: nil)
+          render json: user_json(@user)
+        end
+
+        private
+
+        def set_user
+          @user = User.find(params[:id])
+        end
+
+        def user_json(user, detail: false)
+          data = {
+            id: user.id,
+            email: user.email,
+            nickname: user.nickname,
+            role: user.role,
+            status: user.status,
+            banned_reason: user.banned_reason,
+            family_role: user.family_role,
+            prefecture: user.prefecture,
+            admin_memo: user.admin_memo,
+            last_sign_in_at: user.last_sign_in_at,
+            created_at: user.created_at
+          }
+
+          if detail
+            data[:recent_price_records] = user.price_records
+              .includes(:product, :shop)
+              .order(created_at: :desc)
+              .limit(5)
+              .map { |r|
+                {
+                  id: r.id,
+                  price: r.price,
+                  product_name: r.product&.name,
+                  shop_name: r.shop&.name,
+                  purchased_at: r.purchased_at
+                }
+              }
+            data[:recent_products] = user.products
+              .order(created_at: :desc)
+              .limit(5)
+              .map { |p| { id: p.id, name: p.name } }
+          end
+
+          data
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,6 +140,28 @@ Rails.application.routes.draw do
       post "family_invites/apply_code",     to: "family_invites#apply_code"
       get  "family_invites/:token",         to: "family_invites#show"
       post "family_invites/:token/join",    to: "family_invites#join"
+
+      # 管理画面API（管理者のみ）
+      namespace :admin do
+        get "dashboard", to: "dashboards#index"
+        get  "users",       to: "users#index"
+        get  "users/:id",   to: "users#show",   as: :user
+        patch "users/:id",  to: "users#update"
+        patch "users/:id/ban",   to: "users#ban",   as: :ban_user
+        patch "users/:id/unban", to: "users#unban", as: :unban_user
+        get   "contacts",       to: "contacts#index"
+        get   "contacts/:id",   to: "contacts#show",   as: :contact
+        patch "contacts/:id",   to: "contacts#update"
+        get   "families",       to: "families#index"
+        get   "families/:id",   to: "families#show",   as: :family
+        patch "families/:id/change_admin",              to: "families#change_admin",  as: :change_admin_family
+        delete "families/:id/members/:user_id",         to: "families#remove_member", as: :remove_family_member
+        get  "stats",                        to: "stats#index"
+        get  "stats/autocomplete_products",  to: "stats#autocomplete_products"
+        get  "stats/autocomplete_shops",     to: "stats#autocomplete_shops"
+        get  "services",         to: "services#index"
+        get  "abnormal_prices",  to: "abnormal_prices#index"
+      end
     end
   end
 

--- a/frontend/src/app/admin/abnormal_prices/page.tsx
+++ b/frontend/src/app/admin/abnormal_prices/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import useSWR from "swr";
+import { apiFetch } from "@/lib/api";
+
+type AbnormalRecord = {
+  id: number;
+  price: number;
+  product_name: string;
+  shop_name: string | null;
+  user_nickname: string | null;
+  purchased_at: string;
+  z_score?: number;
+};
+
+export default function AdminAbnormalPricesPage() {
+  const { data, isLoading } = useSWR<AbnormalRecord[]>(
+    "/api/v1/admin/abnormal_prices",
+    (path: string) => apiFetch<AbnormalRecord[]>(path)
+  );
+
+  if (isLoading) return <p className="text-gray-500">読み込み中...</p>;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold text-gray-800">異常価格</h1>
+      <p className="text-sm text-gray-500">統計的に外れ値とみなされる価格記録の一覧です。</p>
+
+      {!data || data.length === 0 ? (
+        <div className="bg-white rounded-xl shadow border border-gray-100 p-8 text-center text-gray-500 text-sm">
+          異常価格は検出されていません
+        </div>
+      ) : (
+        <div className="bg-white rounded-xl shadow border border-gray-100 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 text-gray-600">
+              <tr>
+                <th className="px-4 py-3 text-left">商品名</th>
+                <th className="px-4 py-3 text-left">価格</th>
+                <th className="px-4 py-3 text-left">店舗</th>
+                <th className="px-4 py-3 text-left">ユーザー</th>
+                <th className="px-4 py-3 text-left">日付</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {data.map((r) => (
+                <tr key={r.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 font-medium">{r.product_name}</td>
+                  <td className="px-4 py-3 text-red-600 font-semibold">¥{r.price.toLocaleString()}</td>
+                  <td className="px-4 py-3 text-gray-500">{r.shop_name ?? "—"}</td>
+                  <td className="px-4 py-3 text-gray-500">{r.user_nickname ?? "—"}</td>
+                  <td className="px-4 py-3 text-gray-500">{r.purchased_at}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/admin/contacts/[id]/page.tsx
+++ b/frontend/src/app/admin/contacts/[id]/page.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { use, useState } from "react";
+import useSWR from "swr";
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+import type { AdminContact } from "@/types";
+
+const STATUS_OPTIONS = [
+  { value: "unread", label: "未読" },
+  { value: "pending", label: "対応中" },
+  { value: "resolved", label: "解決済み" },
+];
+
+export default function AdminContactDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const { data: contact, isLoading, mutate } = useSWR<AdminContact>(
+    `/api/v1/admin/contacts/${id}`,
+    (path: string) => apiFetch<AdminContact>(path)
+  );
+
+  const [status, setStatus] = useState<string>("");
+  const [memo, setMemo] = useState("");
+  const [editing, setEditing] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  if (isLoading || !contact) return <p className="text-gray-500">読み込み中...</p>;
+
+  function startEdit() {
+    setStatus(contact!.status);
+    setMemo(contact!.admin_memo ?? "");
+    setEditing(true);
+  }
+
+  async function handleSave() {
+    await apiFetch(`/api/v1/admin/contacts/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ contact: { status, admin_memo: memo } }),
+    });
+    mutate();
+    setEditing(false);
+    setMessage("更新しました");
+  }
+
+  return (
+    <div className="space-y-4 max-w-2xl">
+      <div className="flex items-center gap-3">
+        <Link href="/admin/contacts" className="text-gray-400 hover:text-gray-600 text-sm">← 一覧</Link>
+        <h1 className="text-2xl font-bold text-gray-800">お問い合わせ詳細</h1>
+      </div>
+
+      {message && <p className="text-green-600 text-sm font-semibold">{message}</p>}
+
+      <div className="bg-white rounded-xl shadow border border-gray-100 p-5 space-y-3 text-sm">
+        <div className="flex gap-4"><span className="text-gray-500 w-28">ニックネーム</span><span>{contact.nickname}</span></div>
+        <div className="flex gap-4"><span className="text-gray-500 w-28">メール</span><span>{contact.email}</span></div>
+        <div className="flex gap-4"><span className="text-gray-500 w-28">日時</span><span>{new Date(contact.created_at).toLocaleString("ja-JP")}</span></div>
+        <div>
+          <p className="text-gray-500 mb-1">お問い合わせ内容</p>
+          <p className="bg-gray-50 rounded-lg p-3 whitespace-pre-wrap text-gray-700">{contact.body}</p>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-xl shadow border border-gray-100 p-5">
+        <div className="flex justify-between items-center mb-3">
+          <p className="font-semibold text-gray-700 text-sm">対応状況</p>
+          {!editing && <button onClick={startEdit} className="text-xs text-orange-500 hover:underline">編集</button>}
+        </div>
+        {editing ? (
+          <div className="space-y-3">
+            <select value={status} onChange={(e) => setStatus(e.target.value)}
+              className="border border-gray-300 rounded-lg px-3 py-2 text-sm w-full">
+              {STATUS_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+            </select>
+            <textarea value={memo} onChange={(e) => setMemo(e.target.value)}
+              placeholder="管理者メモ"
+              className="border border-gray-300 rounded-lg p-2 text-sm w-full focus:ring-2 focus:ring-orange-400 outline-none" rows={3} />
+            <div className="flex gap-2">
+              <button onClick={handleSave} className="bg-orange-500 text-white text-xs px-3 py-1.5 rounded-lg hover:bg-orange-600">保存</button>
+              <button onClick={() => setEditing(false)} className="text-xs text-gray-500 hover:underline">キャンセル</button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-2 text-sm">
+            <p>ステータス: <span className="font-semibold">{STATUS_OPTIONS.find((o) => o.value === contact.status)?.label}</span></p>
+            <p className="text-gray-600 whitespace-pre-wrap">{contact.admin_memo || "メモなし"}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/contacts/page.tsx
+++ b/frontend/src/app/admin/contacts/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+import type { AdminContact } from "@/types";
+
+type Response = { contacts: AdminContact[]; meta: { total: number; page: number; per: number } };
+
+const STATUS_LABELS: Record<string, string> = {
+  unread: "未読",
+  pending: "対応中",
+  resolved: "解決済み",
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  unread: "bg-red-100 text-red-600",
+  pending: "bg-yellow-100 text-yellow-700",
+  resolved: "bg-green-100 text-green-600",
+};
+
+export default function AdminContactsPage() {
+  const [status, setStatus] = useState("");
+  const [page, setPage] = useState(1);
+
+  const { data, isLoading } = useSWR<Response>(
+    `/api/v1/admin/contacts?status=${status}&page=${page}`,
+    (path: string) => apiFetch<Response>(path)
+  );
+
+  const totalPages = data ? Math.ceil(data.meta.total / data.meta.per) : 1;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold text-gray-800">お問い合わせ管理</h1>
+
+      <div className="flex gap-2">
+        {["", "unread", "pending", "resolved"].map((s) => (
+          <button
+            key={s}
+            onClick={() => { setStatus(s); setPage(1); }}
+            className={`text-sm px-3 py-1.5 rounded-lg border transition ${
+              status === s ? "bg-orange-500 text-white border-orange-500" : "bg-white text-gray-600 hover:bg-gray-50"
+            }`}
+          >
+            {s === "" ? "すべて" : STATUS_LABELS[s]}
+          </button>
+        ))}
+      </div>
+
+      {isLoading ? (
+        <p className="text-gray-500 text-sm">読み込み中...</p>
+      ) : (
+        <>
+          <p className="text-sm text-gray-500">全 {data?.meta.total} 件</p>
+          <div className="bg-white rounded-xl shadow border border-gray-100 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 text-gray-600">
+                <tr>
+                  <th className="px-4 py-3 text-left">ID</th>
+                  <th className="px-4 py-3 text-left">ニックネーム</th>
+                  <th className="px-4 py-3 text-left">メール</th>
+                  <th className="px-4 py-3 text-left">ステータス</th>
+                  <th className="px-4 py-3 text-left">日時</th>
+                  <th className="px-4 py-3"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {data?.contacts.map((c) => (
+                  <tr key={c.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 text-gray-500">{c.id}</td>
+                    <td className="px-4 py-3">{c.nickname}</td>
+                    <td className="px-4 py-3">{c.email}</td>
+                    <td className="px-4 py-3">
+                      <span className={`px-2 py-0.5 rounded text-xs font-semibold ${STATUS_COLORS[c.status]}`}>
+                        {STATUS_LABELS[c.status]}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-gray-500">
+                      {new Date(c.created_at).toLocaleDateString("ja-JP")}
+                    </td>
+                    <td className="px-4 py-3">
+                      <Link href={`/admin/contacts/${c.id}`} className="text-orange-500 hover:underline text-xs">
+                        詳細
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex gap-2 text-sm">
+              <button disabled={page <= 1} onClick={() => setPage(page - 1)}
+                className="px-3 py-1.5 border rounded-lg disabled:opacity-40 hover:bg-gray-50">←</button>
+              <span className="px-3 py-1.5 text-gray-600">{page} / {totalPages}</span>
+              <button disabled={page >= totalPages} onClick={() => setPage(page + 1)}
+                className="px-3 py-1.5 border rounded-lg disabled:opacity-40 hover:bg-gray-50">→</button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/admin/families/[id]/page.tsx
+++ b/frontend/src/app/admin/families/[id]/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { use } from "react";
+import useSWR from "swr";
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+import type { AdminFamily } from "@/types";
+
+export default function AdminFamilyDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const { data: family, isLoading, mutate } = useSWR<AdminFamily>(
+    `/api/v1/admin/families/${id}`,
+    (path: string) => apiFetch<AdminFamily>(path)
+  );
+
+  if (isLoading || !family) return <p className="text-gray-500">読み込み中...</p>;
+
+  async function handleChangeAdmin(userId: number) {
+    const target = family!.members?.find((m) => m.id === userId);
+    if (!confirm(`${target?.nickname ?? "このユーザー"} を管理者にしますか？`)) return;
+    await apiFetch(`/api/v1/admin/families/${id}/change_admin`, {
+      method: "PATCH",
+      body: JSON.stringify({ user_id: userId }),
+    });
+    mutate();
+  }
+
+  async function handleRemoveMember(userId: number) {
+    const target = family!.members?.find((m) => m.id === userId);
+    if (!confirm(`${target?.nickname ?? "このユーザー"} を除名しますか？`)) return;
+    await apiFetch(`/api/v1/admin/families/${id}/members/${userId}`, { method: "DELETE" });
+    mutate();
+  }
+
+  return (
+    <div className="space-y-4 max-w-2xl">
+      <div className="flex items-center gap-3">
+        <Link href="/admin/families" className="text-gray-400 hover:text-gray-600 text-sm">← 一覧</Link>
+        <h1 className="text-2xl font-bold text-gray-800">ファミリー詳細</h1>
+      </div>
+
+      <div className="bg-white rounded-xl shadow border border-gray-100 p-5 text-sm space-y-2">
+        <div className="flex gap-4"><span className="text-gray-500 w-28">ID</span><span>{family.id}</span></div>
+        <div className="flex gap-4"><span className="text-gray-500 w-28">名前</span><span className="font-medium">{family.name}</span></div>
+        <div className="flex gap-4"><span className="text-gray-500 w-28">メンバー数</span><span>{family.members_count} 人</span></div>
+        <div className="flex gap-4"><span className="text-gray-500 w-28">作成日</span><span>{new Date(family.created_at).toLocaleString("ja-JP")}</span></div>
+      </div>
+
+      <div className="bg-white rounded-xl shadow border border-gray-100 overflow-hidden">
+        <p className="px-5 py-3 font-semibold text-gray-700 text-sm border-b border-gray-100">メンバー一覧</p>
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 text-gray-600">
+            <tr>
+              <th className="px-4 py-3 text-left">ニックネーム</th>
+              <th className="px-4 py-3 text-left">メール</th>
+              <th className="px-4 py-3 text-left">ロール</th>
+              <th className="px-4 py-3"></th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {family.members?.map((member) => (
+              <tr key={member.id} className="hover:bg-gray-50">
+                <td className="px-4 py-3">{member.nickname ?? "—"}</td>
+                <td className="px-4 py-3 text-gray-500">{member.email}</td>
+                <td className="px-4 py-3">
+                  {member.family_role === "family_admin" ? (
+                    <span className="text-xs bg-orange-100 text-orange-600 px-2 py-0.5 rounded">管理者</span>
+                  ) : (
+                    <span className="text-xs text-gray-500">メンバー</span>
+                  )}
+                </td>
+                <td className="px-4 py-3 space-x-3">
+                  {member.family_role !== "family_admin" && (
+                    <button onClick={() => handleChangeAdmin(member.id)}
+                      className="text-xs text-orange-500 hover:underline">管理者に変更</button>
+                  )}
+                  <button onClick={() => handleRemoveMember(member.id)}
+                    className="text-xs text-red-500 hover:underline">除名</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/families/page.tsx
+++ b/frontend/src/app/admin/families/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+import type { AdminFamily } from "@/types";
+
+type Response = { families: AdminFamily[]; meta: { total: number; page: number; per: number } };
+
+export default function AdminFamiliesPage() {
+  const [page, setPage] = useState(1);
+
+  const { data, isLoading } = useSWR<Response>(
+    `/api/v1/admin/families?page=${page}`,
+    (path: string) => apiFetch<Response>(path)
+  );
+
+  const totalPages = data ? Math.ceil(data.meta.total / data.meta.per) : 1;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold text-gray-800">ファミリー管理</h1>
+
+      {isLoading ? (
+        <p className="text-gray-500 text-sm">読み込み中...</p>
+      ) : (
+        <>
+          <p className="text-sm text-gray-500">全 {data?.meta.total} 件</p>
+          <div className="bg-white rounded-xl shadow border border-gray-100 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 text-gray-600">
+                <tr>
+                  <th className="px-4 py-3 text-left">ID</th>
+                  <th className="px-4 py-3 text-left">ファミリー名</th>
+                  <th className="px-4 py-3 text-left">メンバー数</th>
+                  <th className="px-4 py-3 text-left">作成日</th>
+                  <th className="px-4 py-3"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {data?.families.map((f) => (
+                  <tr key={f.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 text-gray-500">{f.id}</td>
+                    <td className="px-4 py-3 font-medium">{f.name}</td>
+                    <td className="px-4 py-3">{f.members_count} 人</td>
+                    <td className="px-4 py-3 text-gray-500">
+                      {new Date(f.created_at).toLocaleDateString("ja-JP")}
+                    </td>
+                    <td className="px-4 py-3">
+                      <Link href={`/admin/families/${f.id}`} className="text-orange-500 hover:underline text-xs">
+                        詳細
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex gap-2 text-sm">
+              <button disabled={page <= 1} onClick={() => setPage(page - 1)}
+                className="px-3 py-1.5 border rounded-lg disabled:opacity-40 hover:bg-gray-50">←</button>
+              <span className="px-3 py-1.5 text-gray-600">{page} / {totalPages}</span>
+              <button disabled={page >= totalPages} onClick={() => setPage(page + 1)}
+                className="px-3 py-1.5 border rounded-lg disabled:opacity-40 hover:bg-gray-50">→</button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useAuth } from "@/hooks/useAuth";
+
+const NAV_ITEMS = [
+  { href: "/admin", label: "ダッシュボード" },
+  { href: "/admin/users", label: "ユーザー" },
+  { href: "/admin/contacts", label: "お問い合わせ" },
+  { href: "/admin/families", label: "ファミリー" },
+  { href: "/admin/stats", label: "価格統計" },
+  { href: "/admin/abnormal_prices", label: "異常価格" },
+  { href: "/admin/services", label: "サービス概要" },
+];
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const { user, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (!user?.role || user.role !== "admin") {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-red-500">権限がありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-100">
+      {/* サイドバー + コンテンツ */}
+      <div className="flex">
+        <aside className="w-56 min-h-screen bg-gray-900 text-white flex-shrink-0">
+          <div className="px-4 py-5 text-lg font-bold border-b border-gray-700">
+            管理画面
+          </div>
+          <nav className="mt-2">
+            {NAV_ITEMS.map((item) => {
+              const isActive =
+                item.href === "/admin"
+                  ? pathname === "/admin"
+                  : pathname.startsWith(item.href);
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={`block px-4 py-2.5 text-sm transition ${
+                    isActive
+                      ? "bg-orange-600 text-white"
+                      : "text-gray-300 hover:bg-gray-800"
+                  }`}
+                >
+                  {item.label}
+                </Link>
+              );
+            })}
+          </nav>
+        </aside>
+
+        <main className="flex-1 p-6 overflow-auto">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import useSWR from "swr";
+import { apiFetch } from "@/lib/api";
+import type { AdminDashboard } from "@/types";
+import Link from "next/link";
+
+function StatCard({ label, value, sub }: { label: string; value: number; sub?: string }) {
+  return (
+    <div className="bg-white rounded-xl shadow p-5 border border-gray-100">
+      <p className="text-sm text-gray-500">{label}</p>
+      <p className="text-3xl font-bold text-gray-800 mt-1">{value.toLocaleString()}</p>
+      {sub && <p className="text-xs text-gray-400 mt-1">{sub}</p>}
+    </div>
+  );
+}
+
+export default function AdminDashboardPage() {
+  const { data, isLoading } = useSWR<AdminDashboard>(
+    "/api/v1/admin/dashboard",
+    (path: string) => apiFetch<AdminDashboard>(path)
+  );
+
+  if (isLoading || !data) {
+    return <p className="text-gray-500">読み込み中...</p>;
+  }
+
+  const diff = (n: number) => (n >= 0 ? `+${n}` : `${n}`);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-gray-800">ダッシュボード</h1>
+
+      {/* KPI カード */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <StatCard
+          label="本日の新規ユーザー"
+          value={data.new_users_today}
+          sub={`前日比 ${diff(data.new_users_diff)}`}
+        />
+        <StatCard label="アクティブユーザー（30日）" value={data.active_users} />
+        <StatCard
+          label="新規ユーザー（30日）"
+          value={data.new_users_30d}
+          sub={`前月比 ${diff(data.new_users_30d_diff)}`}
+        />
+        <StatCard label="総ファミリー数" value={data.total_families} />
+      </div>
+
+      {/* アラート */}
+      {data.unresolved_contacts > 0 && (
+        <Link
+          href="/admin/contacts"
+          className="block bg-red-50 border border-red-200 rounded-xl p-4 text-red-700 text-sm font-semibold hover:bg-red-100 transition"
+        >
+          未読お問い合わせが {data.unresolved_contacts} 件あります →
+        </Link>
+      )}
+
+      {/* TOP 商品・店舗 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="bg-white rounded-xl shadow p-5 border border-gray-100">
+          <p className="font-semibold text-gray-700 mb-3">価格記録の多い商品 TOP5</p>
+          <ol className="space-y-1.5">
+            {data.top_products.map((p, i) => (
+              <li key={p.name} className="flex justify-between text-sm text-gray-700">
+                <span>{i + 1}. {p.name}</span>
+                <span className="text-gray-400">{p.records_count} 件</span>
+              </li>
+            ))}
+          </ol>
+        </div>
+        <div className="bg-white rounded-xl shadow p-5 border border-gray-100">
+          <p className="font-semibold text-gray-700 mb-3">価格記録の多い店舗 TOP5</p>
+          <ol className="space-y-1.5">
+            {data.top_shops.map((s, i) => (
+              <li key={s.name} className="flex justify-between text-sm text-gray-700">
+                <span>{i + 1}. {s.name}</span>
+                <span className="text-gray-400">{s.records_count} 件</span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/services/page.tsx
+++ b/frontend/src/app/admin/services/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import useSWR from "swr";
+import { apiFetch } from "@/lib/api";
+import type { AdminServices } from "@/types";
+
+export default function AdminServicesPage() {
+  const { data, isLoading } = useSWR<AdminServices>(
+    "/api/v1/admin/services",
+    (path: string) => apiFetch<AdminServices>(path)
+  );
+
+  if (isLoading || !data) return <p className="text-gray-500">読み込み中...</p>;
+
+  const stats = [
+    { label: "総ユーザー数", value: data.users_count.toLocaleString() },
+    { label: "総商品数", value: data.products_count.toLocaleString() },
+    { label: "総価格記録数", value: data.price_records_count.toLocaleString() },
+    { label: "総店舗数", value: data.shops_count.toLocaleString() },
+    { label: "総ファミリー数", value: data.families_count.toLocaleString() },
+    { label: "アクティブユーザー（30日）", value: data.active_users_count.toLocaleString() },
+    { label: "平均記録数/アクティブユーザー", value: String(data.avg_records_per_user) },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-gray-800">サービス概要</h1>
+
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        {stats.map((s) => (
+          <div key={s.label} className="bg-white rounded-xl shadow p-5 border border-gray-100">
+            <p className="text-xs text-gray-500">{s.label}</p>
+            <p className="text-2xl font-bold text-gray-800 mt-1">{s.value}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="bg-white rounded-xl shadow border border-gray-100 p-5">
+        <p className="font-semibold text-gray-700 mb-3">システム情報</p>
+        <dl className="space-y-2 text-sm">
+          {[
+            { label: "Rails バージョン", value: data.rails_version },
+            { label: "Ruby バージョン", value: data.ruby_version },
+            { label: "環境", value: data.env },
+            { label: "DB接続", value: data.db_connected ? "正常" : "エラー" },
+          ].map((item) => (
+            <div key={item.label} className="flex gap-4">
+              <dt className="text-gray-500 w-40">{item.label}</dt>
+              <dd className="font-mono text-gray-700">{item.value}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/stats/page.tsx
+++ b/frontend/src/app/admin/stats/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+import { apiFetch } from "@/lib/api";
+
+type StatsData = {
+  count: number;
+  min_price: number | null;
+  max_price: number | null;
+  avg_price: number | null;
+  top_products_by_records: { name: string; count: number }[];
+  top_shops: { name: string; count: number }[];
+};
+
+export default function AdminStatsPage() {
+  const [keyword, setKeyword] = useState("");
+  const [shopName, setShopName] = useState("");
+  const [pref, setPref] = useState("");
+  const [submitted, setSubmitted] = useState({ keyword: "", shopName: "", pref: "" });
+
+  const params = new URLSearchParams();
+  if (submitted.keyword) params.set("keyword", submitted.keyword);
+  if (submitted.shopName) params.set("shop_name", submitted.shopName);
+  if (submitted.pref) params.set("pref", submitted.pref);
+
+  const { data, isLoading } = useSWR<StatsData>(
+    `/api/v1/admin/stats?${params.toString()}`,
+    (path: string) => apiFetch<StatsData>(path)
+  );
+
+  function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitted({ keyword, shopName, pref });
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold text-gray-800">価格統計</h1>
+
+      <form onSubmit={handleSearch} className="bg-white rounded-xl shadow border border-gray-100 p-5 flex flex-wrap gap-3">
+        <input type="text" value={keyword} onChange={(e) => setKeyword(e.target.value)}
+          placeholder="商品名" className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-orange-400 outline-none" />
+        <input type="text" value={shopName} onChange={(e) => setShopName(e.target.value)}
+          placeholder="店舗名" className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-orange-400 outline-none" />
+        <input type="text" value={pref} onChange={(e) => setPref(e.target.value)}
+          placeholder="都道府県" className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-orange-400 outline-none" />
+        <button type="submit" className="bg-orange-500 hover:bg-orange-600 text-white text-sm font-semibold px-4 py-2 rounded-lg transition">
+          検索
+        </button>
+      </form>
+
+      {isLoading ? (
+        <p className="text-gray-500 text-sm">読み込み中...</p>
+      ) : data ? (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {[
+              { label: "対象件数", value: data.count.toLocaleString() + " 件" },
+              { label: "最安値", value: data.min_price != null ? `¥${data.min_price.toLocaleString()}` : "—" },
+              { label: "最高値", value: data.max_price != null ? `¥${data.max_price.toLocaleString()}` : "—" },
+              { label: "平均価格", value: data.avg_price != null ? `¥${data.avg_price.toLocaleString()}` : "—" },
+            ].map((s) => (
+              <div key={s.label} className="bg-white rounded-xl shadow p-4 border border-gray-100">
+                <p className="text-xs text-gray-500">{s.label}</p>
+                <p className="text-xl font-bold text-gray-800 mt-1">{s.value}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="bg-white rounded-xl shadow border border-gray-100 p-5">
+              <p className="font-semibold text-gray-700 text-sm mb-3">価格記録の多い商品 TOP5</p>
+              <ol className="space-y-1.5 text-sm">
+                {data.top_products_by_records.map((p, i) => (
+                  <li key={p.name} className="flex justify-between">
+                    <span>{i + 1}. {p.name}</span><span className="text-gray-400">{p.count} 件</span>
+                  </li>
+                ))}
+              </ol>
+            </div>
+            <div className="bg-white rounded-xl shadow border border-gray-100 p-5">
+              <p className="font-semibold text-gray-700 text-sm mb-3">登録の多い店舗 TOP5</p>
+              <ol className="space-y-1.5 text-sm">
+                {data.top_shops.map((s, i) => (
+                  <li key={s.name} className="flex justify-between">
+                    <span>{i + 1}. {s.name}</span><span className="text-gray-400">{s.count} 件</span>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/app/admin/users/[id]/page.tsx
+++ b/frontend/src/app/admin/users/[id]/page.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { use, useState } from "react";
+import useSWR from "swr";
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+import type { AdminUser } from "@/types";
+
+export default function AdminUserDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const { data: user, isLoading, mutate } = useSWR<AdminUser>(
+    `/api/v1/admin/users/${id}`,
+    (path: string) => apiFetch<AdminUser>(path)
+  );
+
+  const [memo, setMemo] = useState("");
+  const [editingMemo, setEditingMemo] = useState(false);
+  const [banReason, setBanReason] = useState("");
+  const [showBanForm, setShowBanForm] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  if (isLoading || !user) return <p className="text-gray-500">読み込み中...</p>;
+
+  async function handleMemoSave() {
+    await apiFetch(`/api/v1/admin/users/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ user: { admin_memo: memo } }),
+    });
+    mutate();
+    setEditingMemo(false);
+    setMessage("メモを更新しました");
+  }
+
+  async function handleBan() {
+    await apiFetch(`/api/v1/admin/users/${id}/ban`, {
+      method: "PATCH",
+      body: JSON.stringify({ reason: banReason }),
+    });
+    mutate();
+    setShowBanForm(false);
+    setMessage("BANしました");
+  }
+
+  async function handleUnban() {
+    if (!confirm("BANを解除しますか？")) return;
+    await apiFetch(`/api/v1/admin/users/${id}/unban`, { method: "PATCH" });
+    mutate();
+    setMessage("BAN解除しました");
+  }
+
+  return (
+    <div className="space-y-4 max-w-3xl">
+      <div className="flex items-center gap-3">
+        <Link href="/admin/users" className="text-gray-400 hover:text-gray-600 text-sm">← 一覧</Link>
+        <h1 className="text-2xl font-bold text-gray-800">ユーザー詳細</h1>
+      </div>
+
+      {message && <p className="text-green-600 text-sm font-semibold">{message}</p>}
+
+      {/* 基本情報 */}
+      <div className="bg-white rounded-xl shadow border border-gray-100 p-5 space-y-2 text-sm">
+        <Row label="ID" value={String(user.id)} />
+        <Row label="メール" value={user.email} />
+        <Row label="ニックネーム" value={user.nickname ?? "—"} />
+        <Row label="都道府県" value={user.prefecture ?? "未設定"} />
+        <Row label="ロール" value={user.role} />
+        <Row label="ステータス" value={user.status} />
+        <Row label="家族ロール" value={user.family_role} />
+        <Row label="最終ログイン" value={user.last_sign_in_at ? new Date(user.last_sign_in_at).toLocaleString("ja-JP") : "—"} />
+        <Row label="登録日" value={new Date(user.created_at).toLocaleString("ja-JP")} />
+      </div>
+
+      {/* 管理メモ */}
+      <div className="bg-white rounded-xl shadow border border-gray-100 p-5">
+        <div className="flex justify-between items-center mb-2">
+          <p className="font-semibold text-gray-700 text-sm">管理者メモ</p>
+          <button onClick={() => { setMemo(user.admin_memo ?? ""); setEditingMemo(true); }}
+            className="text-xs text-orange-500 hover:underline">編集</button>
+        </div>
+        {editingMemo ? (
+          <div className="space-y-2">
+            <textarea value={memo} onChange={(e) => setMemo(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg p-2 text-sm focus:ring-2 focus:ring-orange-400 outline-none" rows={3} />
+            <div className="flex gap-2">
+              <button onClick={handleMemoSave} className="bg-orange-500 text-white text-xs px-3 py-1.5 rounded-lg hover:bg-orange-600">保存</button>
+              <button onClick={() => setEditingMemo(false)} className="text-xs text-gray-500 hover:underline">キャンセル</button>
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-gray-600 whitespace-pre-wrap">{user.admin_memo || "—"}</p>
+        )}
+      </div>
+
+      {/* BAN 操作 */}
+      <div className="bg-white rounded-xl shadow border border-gray-100 p-5">
+        <p className="font-semibold text-gray-700 text-sm mb-3">アカウント操作</p>
+        {user.status === "banned" ? (
+          <div className="space-y-2">
+            <p className="text-sm text-red-600">BAN理由: {user.banned_reason ?? "—"}</p>
+            <button onClick={handleUnban} className="text-sm bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-lg transition">
+              BANを解除する
+            </button>
+          </div>
+        ) : (
+          showBanForm ? (
+            <div className="space-y-2">
+              <input type="text" value={banReason} onChange={(e) => setBanReason(e.target.value)}
+                placeholder="BAN理由を入力"
+                className="border border-gray-300 rounded-lg px-3 py-2 text-sm w-full focus:ring-2 focus:ring-red-400 outline-none" />
+              <div className="flex gap-2">
+                <button onClick={handleBan} className="text-sm bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-lg transition">BAN実行</button>
+                <button onClick={() => setShowBanForm(false)} className="text-sm text-gray-500 hover:underline">キャンセル</button>
+              </div>
+            </div>
+          ) : (
+            <button onClick={() => setShowBanForm(true)} className="text-sm text-red-500 border border-red-200 hover:bg-red-50 px-4 py-2 rounded-lg transition">
+              BANする
+            </button>
+          )
+        )}
+      </div>
+
+      {/* 最近の価格記録 */}
+      {user.recent_price_records && user.recent_price_records.length > 0 && (
+        <div className="bg-white rounded-xl shadow border border-gray-100 p-5">
+          <p className="font-semibold text-gray-700 text-sm mb-3">最近の価格記録</p>
+          <table className="w-full text-xs">
+            <thead className="text-gray-500"><tr>
+              <th className="text-left pb-2">商品</th><th className="text-left pb-2">店舗</th>
+              <th className="text-left pb-2">価格</th><th className="text-left pb-2">日付</th>
+            </tr></thead>
+            <tbody className="divide-y divide-gray-50">
+              {user.recent_price_records.map((r) => (
+                <tr key={r.id}>
+                  <td className="py-1.5">{r.product_name ?? "—"}</td>
+                  <td>{r.shop_name ?? "—"}</td>
+                  <td>¥{r.price.toLocaleString()}</td>
+                  <td className="text-gray-400">{r.purchased_at}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex gap-4">
+      <span className="text-gray-500 w-32 flex-shrink-0">{label}</span>
+      <span className="text-gray-800">{value}</span>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+import type { AdminUser } from "@/types";
+
+type Response = { users: AdminUser[]; meta: { total: number; page: number; per: number } };
+
+export default function AdminUsersPage() {
+  const [query, setQuery] = useState("");
+  const [page, setPage] = useState(1);
+  const [input, setInput] = useState("");
+
+  const { data, isLoading } = useSWR<Response>(
+    `/api/v1/admin/users?q=${query}&page=${page}`,
+    (path: string) => apiFetch<Response>(path)
+  );
+
+  function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    setQuery(input);
+    setPage(1);
+  }
+
+  const totalPages = data ? Math.ceil(data.meta.total / data.meta.per) : 1;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold text-gray-800">ユーザー管理</h1>
+
+      <form onSubmit={handleSearch} className="flex gap-2">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="メール・ニックネームで検索"
+          className="border border-gray-300 rounded-lg px-3 py-2 text-sm flex-1 max-w-xs focus:outline-none focus:ring-2 focus:ring-orange-400"
+        />
+        <button type="submit" className="bg-orange-500 hover:bg-orange-600 text-white text-sm font-semibold px-4 py-2 rounded-lg transition">
+          検索
+        </button>
+      </form>
+
+      {isLoading ? (
+        <p className="text-gray-500 text-sm">読み込み中...</p>
+      ) : (
+        <>
+          <p className="text-sm text-gray-500">全 {data?.meta.total} 件</p>
+          <div className="bg-white rounded-xl shadow border border-gray-100 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 text-gray-600">
+                <tr>
+                  <th className="px-4 py-3 text-left">ID</th>
+                  <th className="px-4 py-3 text-left">メール</th>
+                  <th className="px-4 py-3 text-left">ニックネーム</th>
+                  <th className="px-4 py-3 text-left">ステータス</th>
+                  <th className="px-4 py-3 text-left">登録日</th>
+                  <th className="px-4 py-3"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {data?.users.map((user) => (
+                  <tr key={user.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 text-gray-500">{user.id}</td>
+                    <td className="px-4 py-3">{user.email}</td>
+                    <td className="px-4 py-3">{user.nickname ?? "—"}</td>
+                    <td className="px-4 py-3">
+                      <span className={`px-2 py-0.5 rounded text-xs font-semibold ${
+                        user.status === "banned" ? "bg-red-100 text-red-600" : "bg-green-100 text-green-600"
+                      }`}>
+                        {user.status === "banned" ? "BAN" : "正常"}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-gray-500">
+                      {new Date(user.created_at).toLocaleDateString("ja-JP")}
+                    </td>
+                    <td className="px-4 py-3">
+                      <Link href={`/admin/users/${user.id}`} className="text-orange-500 hover:underline text-xs">
+                        詳細
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* ページネーション */}
+          {totalPages > 1 && (
+            <div className="flex gap-2 text-sm">
+              <button
+                disabled={page <= 1}
+                onClick={() => setPage(page - 1)}
+                className="px-3 py-1.5 border rounded-lg disabled:opacity-40 hover:bg-gray-50"
+              >
+                ←
+              </button>
+              <span className="px-3 py-1.5 text-gray-600">{page} / {totalPages}</span>
+              <button
+                disabled={page >= totalPages}
+                onClick={() => setPage(page + 1)}
+                className="px-3 py-1.5 border rounded-lg disabled:opacity-40 hover:bg-gray-50"
+              >
+                →
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -86,3 +86,82 @@ export type Product = {
   memo: string | null;
   category: { id: number; name: string } | null;
 };
+
+/** 管理画面: ユーザー */
+export type AdminUser = {
+  id: number;
+  email: string;
+  nickname: string | null;
+  role: string;
+  status: string;
+  banned_reason: string | null;
+  family_role: string;
+  prefecture: string | null;
+  admin_memo: string | null;
+  last_sign_in_at: string | null;
+  created_at: string;
+  recent_price_records?: {
+    id: number;
+    price: number;
+    product_name: string | null;
+    shop_name: string | null;
+    purchased_at: string;
+  }[];
+  recent_products?: { id: number; name: string }[];
+};
+
+/** 管理画面: お問い合わせ */
+export type AdminContact = {
+  id: number;
+  nickname: string;
+  email: string;
+  body: string;
+  status: "unread" | "pending" | "resolved";
+  admin_memo: string | null;
+  created_at: string;
+};
+
+/** 管理画面: ファミリー */
+export type AdminFamily = {
+  id: number;
+  name: string;
+  invite_token?: string;
+  members_count: number;
+  created_at: string;
+  members?: {
+    id: number;
+    nickname: string | null;
+    email: string;
+    family_role: string;
+    created_at: string;
+  }[];
+};
+
+/** 管理画面: ダッシュボード */
+export type AdminDashboard = {
+  new_users_today: number;
+  new_users_yesterday: number;
+  new_users_diff: number;
+  active_users: number;
+  new_users_30d: number;
+  new_users_30d_diff: number;
+  total_families: number;
+  unresolved_contacts: number;
+  top_products: { name: string; records_count: number }[];
+  top_shops: { name: string; records_count: number }[];
+};
+
+/** 管理画面: サービス概要 */
+export type AdminServices = {
+  users_count: number;
+  products_count: number;
+  price_records_count: number;
+  shops_count: number;
+  families_count: number;
+  active_users_count: number;
+  avg_records_per_user: number;
+  rails_version: string;
+  ruby_version: string;
+  env: string;
+  db_connected: boolean;
+};

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :contact do
+    sequence(:nickname) { |n| "問い合わせユーザー#{n}" }
+    sequence(:email) { |n| "contact#{n}@example.com" }
+    body { "テストのお問い合わせ内容です" }
+    status { :unread }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -31,5 +31,10 @@ FactoryBot.define do
     trait :family_admin do
       family_role { :family_admin }
     end
+
+    # サービス管理者（role: admin）
+    trait :admin do
+      role { :admin }
+    end
   end
 end

--- a/spec/requests/api/v1/admin/contacts_spec.rb
+++ b/spec/requests/api/v1/admin/contacts_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Admin::Contacts", type: :request do
+  let(:admin) { create(:user, :without_callbacks, :admin) }
+  let(:contact) { create(:contact) }
+
+  before { contact }
+
+  describe "GET /api/v1/admin/contacts" do
+    before { sign_in(admin, scope: :user) }
+
+    it "お問い合わせ一覧をJSONで返す" do
+      get "/api/v1/admin/contacts"
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["contacts"]).to be_an(Array)
+      expect(json["meta"]).to have_key("total")
+    end
+  end
+
+  describe "GET /api/v1/admin/contacts/:id" do
+    before { sign_in(admin, scope: :user) }
+
+    it "お問い合わせ詳細をJSONで返す" do
+      get "/api/v1/admin/contacts/#{contact.id}"
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["id"]).to eq(contact.id)
+      expect(json["status"]).to eq("unread")
+    end
+  end
+
+  describe "PATCH /api/v1/admin/contacts/:id" do
+    before { sign_in(admin, scope: :user) }
+
+    it "ステータスとメモを更新できる" do
+      patch "/api/v1/admin/contacts/#{contact.id}",
+            params: { contact: { status: "resolved", admin_memo: "対応済み" } }
+      expect(response).to have_http_status(:ok)
+      expect(contact.reload.status).to eq("resolved")
+    end
+  end
+end

--- a/spec/requests/api/v1/admin/dashboard_spec.rb
+++ b/spec/requests/api/v1/admin/dashboard_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Admin::Dashboard", type: :request do
+  let(:admin) { create(:user, :without_callbacks, :admin) }
+  let(:general) { create(:user, :without_callbacks) }
+
+  describe "GET /api/v1/admin/dashboard" do
+    context "管理者でログイン中" do
+      before { sign_in(admin, scope: :user) }
+
+      it "ダッシュボード統計をJSONで返す" do
+        get "/api/v1/admin/dashboard"
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json).to have_key("new_users_today")
+        expect(json).to have_key("active_users")
+        expect(json).to have_key("total_families")
+        expect(json).to have_key("unresolved_contacts")
+        expect(json).to have_key("top_products")
+        expect(json).to have_key("top_shops")
+      end
+    end
+
+    context "一般ユーザーでログイン中" do
+      before { sign_in(general, scope: :user) }
+
+      it "403を返す" do
+        get "/api/v1/admin/dashboard"
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "未認証" do
+      it "401を返す" do
+        get "/api/v1/admin/dashboard"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/admin/families_spec.rb
+++ b/spec/requests/api/v1/admin/families_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Admin::Families", type: :request do
+  let(:admin) { create(:user, :without_callbacks, :admin) }
+  let(:family_admin_user) { create(:user, :without_callbacks) }
+  let(:member_user) { create(:user, :without_callbacks) }
+  let(:family) do
+    fam = create(:family, owner: family_admin_user)
+    family_admin_user.update!(family: fam, family_role: :family_admin)
+    member_user.update!(family: fam, family_role: :family_member)
+    fam
+  end
+
+  before { family }
+
+  describe "GET /api/v1/admin/families" do
+    before { sign_in(admin, scope: :user) }
+
+    it "ファミリー一覧をJSONで返す" do
+      get "/api/v1/admin/families"
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["families"]).to be_an(Array)
+      expect(json["meta"]).to have_key("total")
+    end
+  end
+
+  describe "GET /api/v1/admin/families/:id" do
+    before { sign_in(admin, scope: :user) }
+
+    it "ファミリー詳細とメンバー一覧をJSONで返す" do
+      get "/api/v1/admin/families/#{family.id}"
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["id"]).to eq(family.id)
+      expect(json["members"]).to be_an(Array)
+      expect(json["members"].size).to eq(2)
+    end
+  end
+
+  describe "PATCH /api/v1/admin/families/:id/change_admin" do
+    before { sign_in(admin, scope: :user) }
+
+    it "ファミリー管理者を変更できる" do
+      patch "/api/v1/admin/families/#{family.id}/change_admin",
+            params: { user_id: member_user.id }
+      expect(response).to have_http_status(:ok)
+      expect(member_user.reload.family_admin?).to be true
+      expect(family_admin_user.reload.family_member?).to be true
+    end
+  end
+
+  describe "DELETE /api/v1/admin/families/:id/members/:user_id" do
+    before { sign_in(admin, scope: :user) }
+
+    it "メンバーを除名できる" do
+      delete "/api/v1/admin/families/#{family.id}/members/#{member_user.id}"
+      expect(response).to have_http_status(:ok)
+      expect(member_user.reload.family_id).to be_nil
+    end
+  end
+end

--- a/spec/requests/api/v1/admin/services_spec.rb
+++ b/spec/requests/api/v1/admin/services_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Admin::Services", type: :request do
+  let(:admin) { create(:user, :without_callbacks, :admin) }
+
+  describe "GET /api/v1/admin/services" do
+    before { sign_in(admin, scope: :user) }
+
+    it "サービス概要をJSONで返す" do
+      get "/api/v1/admin/services"
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json).to have_key("users_count")
+      expect(json).to have_key("price_records_count")
+      expect(json).to have_key("rails_version")
+    end
+  end
+end

--- a/spec/requests/api/v1/admin/stats_spec.rb
+++ b/spec/requests/api/v1/admin/stats_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Admin::Stats", type: :request do
+  let(:admin) { create(:user, :without_callbacks, :admin) }
+
+  before { sign_in(admin, scope: :user) }
+
+  describe "GET /api/v1/admin/stats" do
+    it "統計情報をJSONで返す" do
+      get "/api/v1/admin/stats"
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json).to have_key("count")
+      expect(json).to have_key("top_products_by_records")
+      expect(json).to have_key("top_shops")
+    end
+
+    it "キーワード検索ができる" do
+      get "/api/v1/admin/stats", params: { keyword: "牛乳" }
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /api/v1/admin/stats/autocomplete_products" do
+    it "商品名候補をJSONで返す" do
+      get "/api/v1/admin/stats/autocomplete_products", params: { q: "牛" }
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to be_an(Array)
+    end
+  end
+
+  describe "GET /api/v1/admin/stats/autocomplete_shops" do
+    it "店舗名候補をJSONで返す" do
+      get "/api/v1/admin/stats/autocomplete_shops", params: { q: "スーパー" }
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to be_an(Array)
+    end
+  end
+end

--- a/spec/requests/api/v1/admin/users_spec.rb
+++ b/spec/requests/api/v1/admin/users_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Admin::Users", type: :request do
+  let(:admin) { create(:user, :without_callbacks, :admin) }
+  let(:target_user) { create(:user, :without_callbacks) }
+
+  before { target_user }
+
+  describe "GET /api/v1/admin/users" do
+    before { sign_in(admin, scope: :user) }
+
+    it "ユーザー一覧をJSONで返す" do
+      get "/api/v1/admin/users"
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["users"]).to be_an(Array)
+      expect(json["meta"]).to have_key("total")
+    end
+
+    it "キーワードで検索できる" do
+      get "/api/v1/admin/users", params: { q: target_user.email }
+      json = JSON.parse(response.body)
+      expect(json["users"].map { |u| u["email"] }).to include(target_user.email)
+    end
+  end
+
+  describe "GET /api/v1/admin/users/:id" do
+    before { sign_in(admin, scope: :user) }
+
+    it "ユーザー詳細をJSONで返す" do
+      get "/api/v1/admin/users/#{target_user.id}"
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["id"]).to eq(target_user.id)
+      expect(json["email"]).to eq(target_user.email)
+    end
+  end
+
+  describe "PATCH /api/v1/admin/users/:id" do
+    before { sign_in(admin, scope: :user) }
+
+    it "管理者メモを更新できる" do
+      patch "/api/v1/admin/users/#{target_user.id}",
+            params: { user: { admin_memo: "要観察" } }
+      expect(response).to have_http_status(:ok)
+      expect(target_user.reload.admin_memo).to eq("要観察")
+    end
+  end
+
+  describe "PATCH /api/v1/admin/users/:id/ban" do
+    before { sign_in(admin, scope: :user) }
+
+    it "ユーザーをBANできる" do
+      patch "/api/v1/admin/users/#{target_user.id}/ban",
+            params: { reason: "規約違反" }
+      expect(response).to have_http_status(:ok)
+      expect(target_user.reload.status).to eq("banned")
+    end
+  end
+
+  describe "PATCH /api/v1/admin/users/:id/unban" do
+    before do
+      target_user.update!(status: "banned", banned_reason: "規約違反")
+      sign_in(admin, scope: :user)
+    end
+
+    it "BANを解除できる" do
+      patch "/api/v1/admin/users/#{target_user.id}/unban"
+      expect(response).to have_http_status(:ok)
+      expect(target_user.reload.status).to eq("active")
+    end
+  end
+
+  context "一般ユーザーでアクセス" do
+    before { sign_in(target_user, scope: :user) }
+
+    it "403を返す" do
+      get "/api/v1/admin/users"
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

管理画面（`/admin/*`）を Next.js へ移行した。Rails 側に `api/v1/admin` 名前空間で JSON API を追加し、Next.js で管理画面 9 画面を実装。

## 変更内容

### Rails（JSON API 追加）

| エンドポイント | 説明 |
|---|---|
| `GET /api/v1/admin/dashboard` | ダッシュボード集計（ユーザー統計・TOP商品/店舗） |
| `GET /api/v1/admin/users` | ユーザー一覧（キーワード検索・ページネーション） |
| `GET /api/v1/admin/users/:id` | ユーザー詳細（直近の価格記録・商品含む） |
| `PATCH /api/v1/admin/users/:id` | 管理者メモ更新 |
| `PATCH /api/v1/admin/users/:id/ban` | BAN |
| `PATCH /api/v1/admin/users/:id/unban` | BAN解除 |
| `GET /api/v1/admin/contacts` | お問い合わせ一覧（ステータス絞り込み） |
| `GET /api/v1/admin/contacts/:id` | お問い合わせ詳細 |
| `PATCH /api/v1/admin/contacts/:id` | ステータス・メモ更新 |
| `GET /api/v1/admin/families` | ファミリー一覧 |
| `GET /api/v1/admin/families/:id` | ファミリー詳細（メンバー一覧） |
| `PATCH /api/v1/admin/families/:id/change_admin` | 管理者変更 |
| `DELETE /api/v1/admin/families/:id/members/:user_id` | メンバー除名 |
| `GET /api/v1/admin/stats` | 価格統計（商品名/店舗/都道府県検索） |
| `GET /api/v1/admin/stats/autocomplete_*` | オートコンプリート |
| `GET /api/v1/admin/abnormal_prices` | 異常価格一覧 |
| `GET /api/v1/admin/services` | サービス概要・システム情報 |

### Next.js（新規画面）

| 画面 | URL |
|---|---|
| ダッシュボード | `/admin` |
| ユーザー一覧 | `/admin/users` |
| ユーザー詳細 | `/admin/users/[id]` |
| お問い合わせ一覧 | `/admin/contacts` |
| お問い合わせ詳細 | `/admin/contacts/[id]` |
| ファミリー一覧 | `/admin/families` |
| ファミリー詳細 | `/admin/families/[id]` |
| 価格統計 | `/admin/stats` |
| 異常価格 | `/admin/abnormal_prices` |
| サービス概要 | `/admin/services` |

### その他
- `admin/layout.tsx`：サイドバーナビ付き共通レイアウト（管理者のみアクセス可）
- 型定義追加：`AdminUser` / `AdminContact` / `AdminFamily` / `AdminDashboard` / `AdminServices`
- ファクトリー追加：`contacts.rb`、`users` に `:admin` trait 追加

## 受入テスト項目

- [ ] 管理者ユーザーで `/admin` にアクセスするとダッシュボードが表示される
- [ ] 一般ユーザーでアクセスすると「権限がありません」と表示される
- [ ] ユーザー一覧でメール・ニックネーム検索ができる
- [ ] ユーザー詳細で BAN / BAN解除ができる
- [ ] お問い合わせのステータスを更新できる
- [ ] ファミリーの管理者を変更できる、メンバーを除名できる
- [ ] 価格統計で商品名検索後に集計結果が表示される
- [ ] サービス概要にシステム情報（Rails/Ruby バージョン）が表示される

## 確認手順

```bash
# Rails テスト
bundle exec rspec spec/requests/api/v1/admin/

# Next.js テスト
cd frontend && npm test
```

## 影響範囲

- 既存の Rails 管理画面（HTML レスポンス）は変更なし
- iOS からは管理画面にアクセスしないため影響なし

Closes #204