### PR TITLE
next.config.ts に / → /home のリダイレクトを追加

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async redirects() {
+    return [
+      {
+        source: "/",
+        destination: "/home",
+        permanent: false,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 概要

PR #206 マージ後に追加したコミットを main に取り込む。

## 変更内容

- `frontend/next.config.ts`: `async redirects()` で `/` → `/home` へのリダイレクトを設定
  - `page.tsx` の `redirect()` だけでは Vercel で 404 になるケースがあるため、フレームワークレベルで対応