### PR TITLE
本番環境でサブドメイン間のセッション Cookie 共有を設定

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,11 @@
+# 本番環境では .okaimonote.com 配下のサブドメイン間でセッション Cookie を共有する
+# www.okaimonote.com（Next.js）と api.okaimonote.com（Rails）が同一ルートドメインのため
+# domain: '.okaimonote.com' を設定することでブラウザが Cookie を両方に送信する
+
+if Rails.env.production?
+  Rails.application.config.session_store :cookie_store,
+    key: "_okaimonote_session",
+    domain: ".okaimonote.com",
+    secure: true,
+    same_site: :lax
+end


### PR DESCRIPTION
## Summary
- `config/initializers/session_store.rb` を新規作成
- 本番環境のみ `domain: '.okaimonote.com'` を設定
- `www.okaimonote.com`（Vercel）から `api.okaimonote.com`（Render）への API リクエスト時にセッション Cookie が正しく送信される

## 背景
Vercel（www.okaimonote.com）と Render（api.okaimonote.com）はサブドメインが異なるため、デフォルトのセッション Cookie ではブラウザが送信しない。ルートドメイン `.okaimonote.com` を指定することで両サブドメインで Cookie を共有できる。

## Test plan
- [ ] ローカル動作確認（開発環境は変更なし）
- [ ] Render にデプロイ後、`www.okaimonote.com` からログインしてセッションが維持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)