### PR TITLE
api.okaimonote.com をホスト認証許可リストに追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,6 +81,7 @@ Rails.application.configure do
 
   config.hosts << "okaimonote.com"
   config.hosts << "www.okaimonote.com"
+  config.hosts << "api.okaimonote.com"
   config.hosts << "okaimonote.onrender.com"
 
   config.active_storage.service = :amazon


### PR DESCRIPTION
## Summary
- `config/environments/production.rb` に `api.okaimonote.com` を追加
- カスタムドメイン経由のリクエストで `Blocked hosts: api.okaimonote.com` エラーが発生していたため修正

## 背景
Render に `api.okaimonote.com` カスタムドメインを設定したが、Rails の HostAuthorization ミドルウェアが未登録ホストをブロックしていた。

## Test plan
- [ ] Render デプロイ後、`https://api.okaimonote.com/api/v1/me` にアクセスして 401 or 200 が返ることを確認（Blocked 403 でないこと）

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)