### PR TITLE
#215 商品一覧に検索・ページネーション・FAB追加、価格記録にフラッシュ対応

### DIFF
--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -1,15 +1,38 @@
 module Api
   module V1
     class ProductsController < BaseController
+      PER_PAGE = 20
+
       # GET /api/v1/products
+      # q パラメータで Ransack 検索対応、Kaminari ページネーション対応
       def index
         owner = current_user.family_owner
-        products = owner.products.includes(:category).order(created_at: :desc)
 
-        render json: products.map { |p| product_json(p) }
+        q = owner.products.includes(:category, image_attachment: :blob)
+                 .ransack(ransack_params)
+
+        products = q.result(distinct: true)
+                    .order(created_at: :desc)
+                    .page(params[:page])
+                    .per(PER_PAGE)
+
+        render json: {
+          data: products.map { |p| product_json(p) },
+          meta: {
+            total: products.total_count,
+            current_page: products.current_page,
+            total_pages: products.total_pages
+          }
+        }
       end
 
       private
+
+      def ransack_params
+        return {} unless params[:q].is_a?(ActionController::Parameters)
+
+        params[:q].permit(:name_cont, :category_id_eq)
+      end
 
       def product_json(product)
         {
@@ -17,7 +40,8 @@ module Api
           public_id: product.public_id,
           name: product.name,
           memo: product.memo,
-          category: product.category ? { id: product.category.id, name: product.category.name } : nil
+          category: product.category ? { id: product.category.id, name: product.category.name } : nil,
+          image_url: product.image.attached? ? url_for(product.image) : nil
         }
       end
     end

--- a/frontend/src/app/price_records/new/page.tsx
+++ b/frontend/src/app/price_records/new/page.tsx
@@ -3,10 +3,12 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { usePriceRecordForm } from "@/hooks/usePriceRecordForm";
+import { useFlash } from "@/contexts/FlashContext";
 
 export default function NewPriceRecordPage() {
   const router = useRouter();
   const { formData, isLoading, createPriceRecord } = usePriceRecordForm();
+  const { flash } = useFlash();
 
   const [productId, setProductId] = useState<number | null>(null);
   const [productName, setProductName] = useState("");
@@ -57,8 +59,10 @@ export default function NewPriceRecordPage() {
         purchased_at: purchasedAt,
         memo: memo.trim() || null,
       });
+      flash("notice", "価格を登録しました");
       router.push("/home");
     } catch {
+      flash("alert", "登録に失敗しました");
       setErrors(["登録に失敗しました"]);
     } finally {
       setSubmitting(false);
@@ -74,7 +78,7 @@ export default function NewPriceRecordPage() {
   }
 
   return (
-    <div className="min-h-screen bg-orange-50 py-6 px-4 sm:px-6 md:px-10">
+    <div className="min-h-screen bg-orange-50 py-6 pb-24 px-4 sm:px-6 md:px-10">
       <div className="max-w-md mx-auto bg-white rounded-2xl shadow p-6 sm:p-8 border border-orange-100">
         <h1 className="text-xl sm:text-2xl font-bold text-center text-orange-500 mb-8">
           🏷 価格登録

--- a/frontend/src/app/products/page.tsx
+++ b/frontend/src/app/products/page.tsx
@@ -1,12 +1,46 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
-import { useProducts } from "@/hooks/useProducts";
+import Image from "next/image";
+import useSWR from "swr";
+import { useProducts, type ProductSearchParams } from "@/hooks/useProducts";
+import { apiFetch } from "@/lib/api";
+import type { PriceRecordFormData } from "@/types";
 
 export default function ProductsPage() {
-  const { products, isLoading } = useProducts();
+  const [page, setPage] = useState(1);
+  const [searchParams, setSearchParams] = useState<ProductSearchParams>({});
+  const [nameInput, setNameInput] = useState("");
+  const [categoryInput, setCategoryInput] = useState("");
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
 
-  if (isLoading) {
+  const { products, meta, isLoading } = useProducts(page, searchParams);
+
+  const { data: formData } = useSWR<PriceRecordFormData>(
+    "/api/v1/price_records/form_data",
+    (path: string) => apiFetch<PriceRecordFormData>(path),
+    { shouldRetryOnError: false }
+  );
+
+  const handleSearch = () => {
+    setPage(1);
+    setSearchParams({
+      name_cont: nameInput || undefined,
+      category_id_eq: categoryInput || undefined,
+    });
+  };
+
+  const handleClear = () => {
+    setNameInput("");
+    setCategoryInput("");
+    setPage(1);
+    setSearchParams({});
+  };
+
+  const hasFilter = nameInput !== "" || categoryInput !== "";
+
+  if (isLoading && products.length === 0) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <p className="text-gray-500">読み込み中...</p>
@@ -15,31 +49,116 @@ export default function ProductsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-orange-50 py-6 px-4 sm:px-6 md:px-10">
+    <div className="min-h-screen bg-orange-50 py-6 pb-24 px-4 sm:px-6 md:px-10">
       <div className="max-w-xl mx-auto">
-        <div className="flex justify-between items-center mb-8">
-          <h1 className="text-2xl font-bold text-orange-500">🛒 商品管理</h1>
-          <Link
-            href="/price_records/new"
-            className="bg-orange-500 hover:bg-orange-600 text-white text-sm font-semibold px-4 py-2 rounded-full shadow-md transition"
+        <h1 className="text-2xl font-bold text-orange-500 mb-6 text-center">
+          🛒 商品管理
+        </h1>
+
+        {/* 検索フィルター */}
+        <div className="mb-6">
+          <button
+            onClick={() => setIsFilterOpen((v) => !v)}
+            className="w-full flex items-center justify-between bg-white border border-orange-200 rounded-2xl px-4 py-3 text-sm font-semibold text-gray-700 shadow-sm hover:bg-orange-50 transition"
           >
-            + 価格登録
-          </Link>
+            <span className="flex items-center gap-2">
+              🔍 検索・絞り込み
+              {hasFilter && (
+                <span className="bg-orange-500 text-white text-xs rounded-full px-2 py-0.5">
+                  適用中
+                </span>
+              )}
+            </span>
+            <span className="text-gray-400">{isFilterOpen ? "▲" : "▼"}</span>
+          </button>
+
+          {isFilterOpen && (
+            <div className="mt-2 bg-white border border-orange-100 rounded-2xl p-4 shadow-sm space-y-3">
+              <div>
+                <label className="block text-xs font-semibold text-gray-600 mb-1">
+                  商品名
+                </label>
+                <input
+                  type="text"
+                  value={nameInput}
+                  onChange={(e) => setNameInput(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+                  placeholder="例：牛乳"
+                  className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 text-sm outline-none transition placeholder-gray-400"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-semibold text-gray-600 mb-1">
+                  カテゴリ
+                </label>
+                <select
+                  value={categoryInput}
+                  onChange={(e) => setCategoryInput(e.target.value)}
+                  className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 text-sm outline-none transition bg-white"
+                >
+                  <option value="">すべて</option>
+                  {formData?.categories.map((c) => (
+                    <option key={c.id} value={String(c.id)}>
+                      {c.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex gap-2 pt-1">
+                <button
+                  onClick={handleSearch}
+                  className="flex-1 bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 rounded-full text-sm transition"
+                >
+                  検索
+                </button>
+                <button
+                  onClick={handleClear}
+                  className="flex-1 bg-gray-100 hover:bg-gray-200 text-gray-600 font-semibold py-2 rounded-full text-sm transition"
+                >
+                  クリア
+                </button>
+              </div>
+            </div>
+          )}
         </div>
 
+        {/* 件数 */}
+        {meta && (
+          <p className="text-xs text-gray-500 mb-3 text-right">
+            全 {meta.total} 件
+          </p>
+        )}
+
+        {/* 商品一覧 */}
         {products.length === 0 ? (
           <p className="text-gray-400 text-sm text-center py-10">
-            まだ商品がありません
+            商品が見つかりません
           </p>
         ) : (
           <ul className="space-y-3">
             {products.map((product) => (
               <li
                 key={product.id}
-                className="bg-white rounded-2xl shadow-sm border border-orange-100 px-5 py-4 flex justify-between items-center"
+                className="bg-white rounded-2xl shadow-sm border border-orange-100 px-4 py-3 flex items-center gap-4"
               >
-                <div>
-                  <p className="font-semibold text-gray-800">{product.name}</p>
+                {/* 商品画像 */}
+                <div className="w-14 h-14 rounded-xl overflow-hidden bg-orange-50 border border-orange-100 shrink-0 flex items-center justify-center">
+                  {product.image_url ? (
+                    <Image
+                      src={product.image_url}
+                      alt={product.name}
+                      width={56}
+                      height={56}
+                      className="w-full h-full object-cover"
+                    />
+                  ) : (
+                    <span className="text-2xl">🛍</span>
+                  )}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="font-semibold text-gray-800 truncate">
+                    {product.name}
+                  </p>
                   {product.category && (
                     <p className="text-sm text-gray-500 mt-0.5">
                       {product.category.name}
@@ -50,7 +169,39 @@ export default function ProductsPage() {
             ))}
           </ul>
         )}
+
+        {/* ページネーション */}
+        {meta && meta.total_pages > 1 && (
+          <div className="flex justify-center items-center gap-3 mt-8">
+            <button
+              onClick={() => setPage((p) => Math.max(p - 1, 1))}
+              disabled={page === 1}
+              className="px-4 py-2 rounded-full text-sm font-semibold bg-white border border-orange-200 text-orange-500 disabled:opacity-40 hover:bg-orange-50 transition"
+            >
+              ← 前へ
+            </button>
+            <span className="text-sm text-gray-600">
+              {page} / {meta.total_pages}
+            </span>
+            <button
+              onClick={() => setPage((p) => Math.min(p + 1, meta.total_pages))}
+              disabled={page === meta.total_pages}
+              className="px-4 py-2 rounded-full text-sm font-semibold bg-white border border-orange-200 text-orange-500 disabled:opacity-40 hover:bg-orange-50 transition"
+            >
+              次へ →
+            </button>
+          </div>
+        )}
       </div>
+
+      {/* FAB: 価格登録ボタン */}
+      <Link
+        href="/price_records/new"
+        className="fixed bottom-20 right-5 w-14 h-14 bg-orange-500 hover:bg-orange-600 text-white text-2xl rounded-full shadow-lg flex items-center justify-center transition active:scale-95 z-40"
+        aria-label="価格登録"
+      >
+        ＋
+      </Link>
     </div>
   );
 }

--- a/frontend/src/hooks/useProducts.ts
+++ b/frontend/src/hooks/useProducts.ts
@@ -2,17 +2,38 @@ import useSWR from "swr";
 import { apiFetch } from "@/lib/api";
 import type { Product } from "@/types";
 
+type ProductsResponse = {
+  data: Product[];
+  meta: { total: number; current_page: number; total_pages: number };
+};
+
+export type ProductSearchParams = {
+  name_cont?: string;
+  category_id_eq?: string;
+};
+
 /** 商品一覧を取得するフック */
-export function useProducts() {
-  const { data, error, isLoading } = useSWR<Product[]>(
-    "/api/v1/products",
-    (path: string) => apiFetch<Product[]>(path),
+export function useProducts(page = 1, searchParams?: ProductSearchParams) {
+  const query = [
+    `page=${page}`,
+    ...(searchParams
+      ? Object.entries(searchParams)
+          .filter(([, v]) => v !== "" && v != null)
+          .map(([k, v]) => `q[${k}]=${encodeURIComponent(v!)}`)
+      : []),
+  ].join("&");
+
+  const { data, error, isLoading, mutate } = useSWR<ProductsResponse>(
+    `/api/v1/products?${query}`,
+    (path: string) => apiFetch<ProductsResponse>(path),
     { shouldRetryOnError: false }
   );
 
   return {
-    products: data ?? [],
+    products: data?.data ?? [],
+    meta: data?.meta,
     isLoading,
     error,
+    mutate,
   };
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -85,6 +85,7 @@ export type Product = {
   name: string;
   memo: string | null;
   category: { id: number; name: string } | null;
+  image_url: string | null;
 };
 
 /** 管理画面: ユーザー */


### PR DESCRIPTION
## Summary

- `ProductsController` に Ransack 検索・Kaminari ページネーション（20件/ページ）・Active Storage 画像URL を追加
- `useProducts` フックを検索パラメータ・ページ番号対応に更新
- 商品一覧ページの改善
  - 折りたたみ式検索フィルター（商品名・カテゴリ）
  - 商品画像表示（未設定時は絵文字プレースホルダー）
  - ページネーション（前へ/次へ）
  - 全件数表示
  - FAB（フローティングボタン）で価格登録へ遷移
- 価格記録登録ページに成功・失敗フラッシュメッセージを追加

## Test plan

- [ ] 商品一覧に商品名・カテゴリで絞り込みができる
- [ ] 20件を超えるとページネーションが表示される
- [ ] 商品画像がある場合に表示される
- [ ] FABボタンから価格登録ページに遷移できる
- [ ] 価格登録成功時に「価格を登録しました」フラッシュが表示される
- [ ] 価格登録失敗時に「登録に失敗しました」フラッシュが表示される

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)