### PR TITLE
#216 プロフィールにアバター画像対応、設定ページ改善

### DIFF
--- a/app/controllers/api/v1/profile_controller.rb
+++ b/app/controllers/api/v1/profile_controller.rb
@@ -21,7 +21,7 @@ module Api
       private
 
       def profile_params
-        params.require(:user).permit(:nickname, :prefecture)
+        params.require(:user).permit(:nickname, :prefecture, :avatar)
       end
     end
   end

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
+import Image from "next/image";
 import { useProfile } from "@/hooks/useProfile";
+import { useFlash } from "@/contexts/FlashContext";
 
 const PREFECTURES = [
   "北海道", "青森県", "岩手県", "宮城県", "秋田県", "山形県", "福島県",
@@ -14,32 +16,50 @@ const PREFECTURES = [
 ];
 
 export default function ProfilePage() {
-  const { user, isLoading, updateProfile } = useProfile();
+  const { user, isLoading, updateProfile, uploadAvatar } = useProfile();
+  const { flash } = useFlash();
   const [editing, setEditing] = useState(false);
   const [nickname, setNickname] = useState("");
   const [prefecture, setPrefecture] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [saved, setSaved] = useState(false);
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   function startEdit() {
     setNickname(user?.nickname ?? "");
     setPrefecture(user?.prefecture ?? "");
+    setAvatarPreview(null);
     setEditing(true);
-    setSaved(false);
   }
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
     setSubmitting(true);
     try {
-      await updateProfile({
-        nickname: nickname.trim(),
-        prefecture: prefecture || null,
-      });
+      await updateProfile({ nickname: nickname.trim(), prefecture: prefecture || null });
       setEditing(false);
-      setSaved(true);
+      flash("notice", "プロフィールを更新しました");
+    } catch {
+      flash("alert", "更新に失敗しました");
     } finally {
       setSubmitting(false);
+    }
+  }
+
+  async function handleAvatarChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    // リアルタイムプレビュー
+    const reader = new FileReader();
+    reader.onload = (ev) => setAvatarPreview(ev.target?.result as string);
+    reader.readAsDataURL(file);
+    // アップロード
+    try {
+      await uploadAvatar(file);
+      flash("notice", "アバター画像を更新しました");
+    } catch {
+      flash("alert", "画像のアップロードに失敗しました");
+      setAvatarPreview(null);
     }
   }
 
@@ -51,18 +71,46 @@ export default function ProfilePage() {
     );
   }
 
+  const avatarSrc = avatarPreview ?? user?.avatar_url;
+
   return (
-    <div className="min-h-screen bg-orange-50 py-10 px-4">
+    <div className="min-h-screen bg-orange-50 py-10 pb-24 px-4">
       <div className="max-w-md mx-auto bg-white rounded-2xl shadow border border-orange-100 p-8">
-        <h1 className="text-2xl font-bold text-center text-gray-800 mb-8">
+        <h1 className="text-2xl font-bold text-center text-gray-800 mb-6">
           👤 プロフィール設定
         </h1>
 
-        {saved && (
-          <p className="mb-4 text-center text-green-600 text-sm font-semibold">
-            プロフィールを更新しました
-          </p>
-        )}
+        {/* アバター画像 */}
+        <div className="flex flex-col items-center mb-8">
+          <div className="relative w-24 h-24 rounded-full overflow-hidden bg-orange-100 border-2 border-orange-200 mb-3">
+            {avatarSrc ? (
+              <Image
+                src={avatarSrc}
+                alt="アバター"
+                fill
+                className="object-cover"
+              />
+            ) : (
+              <div className="w-full h-full flex items-center justify-center text-4xl">
+                👤
+              </div>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="text-sm text-orange-500 hover:text-orange-600 font-semibold transition"
+          >
+            画像を変更
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            onChange={handleAvatarChange}
+            className="hidden"
+          />
+        </div>
 
         {editing ? (
           <form onSubmit={handleSave} className="space-y-5">

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,14 +1,18 @@
 "use client";
 
+import { useState } from "react";
+import Image from "next/image";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
+import { useFlash } from "@/contexts/FlashContext";
+import { apiFetch } from "@/lib/api";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
 
 type NavItem = {
   href: string;
   label: string;
-  external?: boolean;
 };
 
 const NAV_ITEMS: NavItem[] = [
@@ -18,14 +22,29 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/family", label: "👨‍👩‍👧 ファミリー設定" },
 ];
 
-const EXTERNAL_ITEMS: NavItem[] = [
-  { href: `${API_BASE}/terms`, label: "利用規約", external: true },
-  { href: `${API_BASE}/privacy`, label: "プライバシーポリシー", external: true },
-  { href: `${API_BASE}/contact`, label: "お問い合わせ", external: true },
+const EXTERNAL_ITEMS = [
+  { href: `${API_BASE}/terms`, label: "利用規約" },
+  { href: `${API_BASE}/privacy`, label: "プライバシーポリシー" },
+  { href: `${API_BASE}/contact`, label: "お問い合わせ" },
 ];
 
 export default function SettingsPage() {
   const { user, isLoading } = useAuth();
+  const { flash } = useFlash();
+  const router = useRouter();
+  const [loggingOut, setLoggingOut] = useState(false);
+
+  async function handleLogout() {
+    setLoggingOut(true);
+    try {
+      await apiFetch("/api/v1/sessions", { method: "DELETE" });
+      flash("notice", "ログアウトしました");
+      router.replace("/login");
+    } catch {
+      flash("alert", "ログアウトに失敗しました");
+      setLoggingOut(false);
+    }
+  }
 
   if (isLoading) {
     return (
@@ -36,7 +55,7 @@ export default function SettingsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-orange-50 py-10 px-4">
+    <div className="min-h-screen bg-orange-50 py-10 pb-24 px-4">
       <div className="max-w-md mx-auto">
         <h1 className="text-2xl font-bold text-center text-orange-500 mb-8">
           ⚙ 設定
@@ -44,11 +63,26 @@ export default function SettingsPage() {
 
         {/* ユーザー情報 */}
         {user && (
-          <div className="bg-white rounded-2xl shadow border border-orange-100 p-5 mb-6 text-center">
-            <p className="text-lg font-bold text-gray-800">
-              {user.nickname ?? "ゲスト"}
-            </p>
-            <p className="text-sm text-gray-500 mt-1">{user.email}</p>
+          <div className="bg-white rounded-2xl shadow border border-orange-100 p-5 mb-6 flex items-center gap-4">
+            <div className="w-14 h-14 rounded-full overflow-hidden bg-orange-100 border-2 border-orange-200 shrink-0 flex items-center justify-center">
+              {user.avatar_url ? (
+                <Image
+                  src={user.avatar_url}
+                  alt="アバター"
+                  width={56}
+                  height={56}
+                  className="w-full h-full object-cover"
+                />
+              ) : (
+                <span className="text-2xl">👤</span>
+              )}
+            </div>
+            <div className="min-w-0">
+              <p className="text-lg font-bold text-gray-800 truncate">
+                {user.nickname ?? "ゲスト"}
+              </p>
+              <p className="text-sm text-gray-500 truncate">{user.email}</p>
+            </div>
           </div>
         )}
 
@@ -83,13 +117,14 @@ export default function SettingsPage() {
         </div>
 
         {/* ログアウト */}
-        <a
-          href={`${API_BASE}/users/sign_out`}
-          data-method="delete"
-          className="block w-full text-center text-red-500 hover:text-red-600 font-semibold py-3 rounded-2xl border border-red-200 hover:bg-red-50 transition"
+        <button
+          type="button"
+          onClick={handleLogout}
+          disabled={loggingOut}
+          className="block w-full text-center text-red-500 hover:text-red-600 disabled:opacity-50 font-semibold py-3 rounded-2xl border border-red-200 hover:bg-red-50 transition"
         >
-          ログアウト
-        </a>
+          {loggingOut ? "ログアウト中..." : "ログアウト"}
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/hooks/useProfile.ts
+++ b/frontend/src/hooks/useProfile.ts
@@ -1,5 +1,5 @@
 import useSWR from "swr";
-import { apiFetch } from "@/lib/api";
+import { apiFetch, apiFetchFormData } from "@/lib/api";
 import type { User } from "@/types";
 
 /** プロフィール情報の取得・更新フック（/api/v1/me + PATCH /api/v1/profile） */
@@ -21,10 +21,19 @@ export function useProfile() {
     mutate(updated, false);
   }
 
+  async function uploadAvatar(file: File) {
+    const formData = new FormData();
+    formData.append("user[avatar]", file);
+    const updated = await apiFetchFormData<User>("/api/v1/profile", formData);
+    mutate(updated, false);
+  }
+
   return {
     user: data,
     isLoading,
     error,
     updateProfile,
+    uploadAvatar,
+    mutate,
   };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,26 @@
 /** Rails API への fetch ラッパー。全リクエストで credentials: include を付けて Devise セッション Cookie を送る */
+// multipart/form-data 用（Content-Type を自動設定させる）
+export async function apiFetchFormData<T>(
+  path: string,
+  formData: FormData,
+  method: "POST" | "PATCH" = "PATCH"
+): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    credentials: "include",
+    body: formData,
+  });
+
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({ error: res.statusText }));
+    throw Object.assign(new Error(error.error ?? res.statusText), {
+      status: res.status,
+    });
+  }
+
+  if (res.status === 204) return undefined as T;
+  return res.json();
+}
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
 
 export async function apiFetch<T>(


### PR DESCRIPTION
## Summary

- `ProfileController` にアバター画像アップロード（`:avatar`）を追加
- `api.ts` に multipart/form-data 送信用 `apiFetchFormData` 関数を追加
- プロフィールページの改善
  - アバター画像表示（未設定時は絵文字プレースホルダー）
  - 画像アップロード（クリックでファイル選択、リアルタイムプレビュー）
  - 保存成功・失敗を FlashMessage で通知
- 設定ページの改善
  - ユーザー情報欄にアバター画像表示
  - ログアウトを `DELETE /api/v1/sessions` + フラッシュメッセージ対応に変更

## Test plan

- [ ] プロフィールページにアバター画像が表示される
- [ ] 「画像を変更」クリックでファイル選択ダイアログが開く
- [ ] 画像選択後にプレビューが即時表示される
- [ ] プロフィール更新後に「プロフィールを更新しました」フラッシュが表示される
- [ ] 設定ページのユーザー情報欄にアバター画像が表示される
- [ ] ログアウト後に「ログアウトしました」フラッシュが表示されてログインページへ遷移する

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)