### PR TITLE
ログイン時500エラー修正：banned?→status_banned?

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ class ApplicationController < ActionController::Base
 
   # BAN状態でログインできない
   def reject_banned_user
-    if current_user&.banned?
+    if current_user&.status_banned?
       sign_out current_user
       redirect_to new_user_session_path, alert: "このアカウントは停止されています。"
     end


### PR DESCRIPTION
## Summary

- `ApplicationController#reject_banned_user` で `current_user&.banned?` を呼んでいたが、`User` モデルに `banned?` メソッドは存在せず `status_banned?` が正しい
- セッション済みユーザーが `/users/sign_in` にアクセスすると `NoMethodError` が発生し 500 を返していた

## Root Cause

```ruby
# Before（誤）
if current_user&.banned?

# After（正）
if current_user&.status_banned?
```

## Test plan

- [ ] ログイン済み状態で `/users/sign_in` にアクセスして 500 が出ないこと
- [ ] BANされたユーザーがログインしようとすると正しく弾かれること
- [ ] 通常ユーザーのログインが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)