### PR TITLE
ログイン500エラー修正：Turbo+クロスホストリダイレクト対応

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -6,4 +6,17 @@ class Users::SessionsController < Devise::SessionsController
       flash[:notice] = "お帰りなさい、#{resource.nickname}さん！".html_safe
     end
   end
+
+  private
+
+  # Turbo Stream リクエスト時は MissingTemplate が発生し、
+  # フォールバックのクロスホストリダイレクトが UnsafeRedirectError を引き起こすため、
+  # 認証済みの場合は allow_other_host: true で明示的にリダイレクトする
+  def respond_with(resource, opts = {})
+    if warden.authenticated?(resource_name)
+      redirect_to opts[:location] || after_sign_in_path_for(resource), allow_other_host: true
+    else
+      super
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Turbo Stream 形式でフォームを送信すると `users/sessions/create.turbo_stream.erb` テンプレートが見つからず `MissingTemplate` が発生
- フォールバックで `https://www.okaimonote.com/home`（別ホスト）へリダイレクトしようとするが Rails 7 がブロック → `UnsafeRedirectError` → 500

## Fix

`SessionsController#respond_with` をオーバーライドし、認証済みの場合は `allow_other_host: true` で明示的にリダイレクトする。

```ruby
def respond_with(resource, opts = {})
  if warden.authenticated?(resource_name)
    redirect_to opts[:location] || after_sign_in_path_for(resource), allow_other_host: true
  else
    super
  end
end
```

## Test plan

- [ ] メール・パスワードでのログインが成功し `/home` に遷移すること
- [ ] 誤ったパスワードでログインした場合にエラーが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)