### PR TITLE
クロスホストリダイレクトエラーを根本修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,6 +40,16 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:account_update, keys: [ :nickname, :avatar, :prefecture ])
   end
 
+  # フロントエンドURLへのクロスホストリダイレクトを一括で許可する
+  # Devise の require_no_authentication など内部リダイレクトも対象になる
+  def redirect_to(options = {}, response_options = {})
+    frontend_url = ENV.fetch("FRONTEND_URL", "https://www.okaimonote.com")
+    if options.is_a?(String) && options.start_with?(frontend_url)
+      response_options[:allow_other_host] = true
+    end
+    super(options, response_options)
+  end
+
   def api_request?
     request.path.start_with?("/ios/")
   end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -9,12 +9,11 @@ class Users::SessionsController < Devise::SessionsController
 
   private
 
-  # Turbo Stream リクエスト時は MissingTemplate が発生し、
-  # フォールバックのクロスホストリダイレクトが UnsafeRedirectError を引き起こすため、
-  # 認証済みの場合は allow_other_host: true で明示的にリダイレクトする
+  # Turbo Stream リクエスト時は MissingTemplate が発生するため、
+  # 認証済みの場合は ApplicationController#redirect_to 経由でリダイレクトする
   def respond_with(resource, opts = {})
     if warden.authenticated?(resource_name)
-      redirect_to opts[:location] || after_sign_in_path_for(resource), allow_other_host: true
+      redirect_to opts[:location] || after_sign_in_path_for(resource)
     else
       super
     end


### PR DESCRIPTION
## Summary

- `/users/sign_up` GET 時にログイン済みユーザーがいると Devise の `require_no_authentication` が `https://www.okaimonote.com/home` にリダイレクトしようとして `UnsafeRedirectError` → 500
- ログイン POST 時も同様の問題が起きていた（前PR #226 で個別対応済みだが根本解決ではなかった）

## Fix

`ApplicationController#redirect_to` をオーバーライドし、`FRONTEND_URL` へのリダイレクト時は `allow_other_host: true` を自動付与。  
これにより Devise 内部のリダイレクトも含め、全ての場面で一括対応できる。

```ruby
def redirect_to(options = {}, response_options = {})
  frontend_url = ENV.fetch("FRONTEND_URL", "https://www.okaimonote.com")
  if options.is_a?(String) && options.start_with?(frontend_url)
    response_options[:allow_other_host] = true
  end
  super(options, response_options)
end
```

PR #226 の `respond_with` オーバーライドも `allow_other_host` 指定が不要になるため整理。

## Test plan

- [ ] メール・パスワードでのログインが成功すること
- [ ] ログイン済み状態で `/users/sign_up` にアクセスしてもエラーにならないこと
- [ ] 新規登録が正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)