### PR TITLE
フロント・バック連携の潜在バグを一括修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Rails マスターキー（config/master.key の内容）
+RAILS_MASTER_KEY=
+
+# フロントエンド URL（クロスホストリダイレクト先に使用）
+# 開発環境: http://localhost:3003
+# 本番環境: https://www.okaimonote.com
+FRONTEND_URL=http://localhost:3003
+
+# デフォルト URL ホスト（OGP・メールURL生成などに使用。プロトコルは含めない）
+# 開発環境: localhost:3000
+# 本番環境: okaimonote.com
+APP_HOST=localhost:3000
+
+# メール送信（Gmail SMTP）
+GMAIL_USER=
+GMAIL_PASS=
+
+# AWS S3（Active Storage）
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+
+# Amazon SES（メール送信）
+SES_SMTP_USERNAME=
+SES_SMTP_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # Ignore all environment files.
 /.env*
+!/.env.example
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -10,6 +10,8 @@ class AccountsController < ApplicationController
     sign_out user
     user.destroy!
 
-    redirect_to root_path, notice: "アカウントを削除しました。ご利用ありがとうございました。"
+    # アカウント削除後は Next.js ログインページへリダイレクト
+    redirect_to "#{ENV.fetch('FRONTEND_URL', 'https://www.okaimonote.com')}/login",
+                notice: "アカウントを削除しました。ご利用ありがとうございました。"
   end
 end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -6,7 +6,11 @@ module Api
       # APIはCSRFトークン不要（Cookieセッション認証はOriginで保護される）
       skip_before_action :verify_authenticity_token
 
+      # ApplicationController の HTML リダイレクト版 BAN チェックを無効化し、
+      # API 向けの JSON 版に差し替える
+      skip_before_action :reject_banned_user
       before_action :authenticate_user!
+      before_action :reject_banned_user_api
 
       private
 
@@ -15,6 +19,14 @@ module Api
         unless current_user
           render json: { error: "ログインが必要です" }, status: :unauthorized
         end
+      end
+
+      # BAN ユーザーには JSON 403 を返す（リダイレクトは行わない）
+      def reject_banned_user_api
+        return unless current_user&.status_banned?
+
+        sign_out current_user
+        render json: { error: "このアカウントは停止されています" }, status: :forbidden
       end
     end
   end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -13,6 +13,8 @@ module Api
         user = User.find_by(email: params[:email])
         if user&.valid_password?(params[:password])
           sign_in(user)
+          # remember_me パラメータが "1" の場合は Devise の記憶機能を有効化
+          user.remember_me! if params[:remember_me] == "1"
           render json: {
             id: user.id,
             email: user.email,

--- a/app/controllers/ios_auth_controller.rb
+++ b/app/controllers/ios_auth_controller.rb
@@ -10,12 +10,17 @@ class IosAuthController < ApplicationController
       purpose: :ios_login
     )
 
+    # BAN されたユーザーはセッション確立を拒否する
+    if user.status_banned?
+      return redirect_to new_user_session_path, alert: "このアカウントは停止されています。"
+    end
+
     # Devise セッションを作成（Cookie を発行）
     sign_in(user)
 
     # Cookie はレスポンスヘッダに自動で含まれる
     redirect_to home_path
   rescue ActiveSupport::MessageVerifier::InvalidSignature
-    render json: { error: "invalid or expired token" }, status: :unauthorized
+    redirect_to new_user_session_path, alert: "無効または期限切れのトークンです。"
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -8,7 +8,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # パスワード変更後の遷移先
   def after_update_path_for(resource)
     if user_signed_in?
-      profile_path             # ログイン中 → プロフィール画面へ
+      # Next.js プロフィールページへリダイレクト（Rails ビューではなくフロントエンドへ）
+      "#{ENV.fetch('FRONTEND_URL', 'https://www.okaimonote.com')}/profile"
     else
       new_user_session_path    # 未ログイン（メール経由）→ ログイン画面へ
     end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -108,7 +108,8 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # デフォルトURLオプションを設定（OGP・メールURL生成などに使用）
-  Rails.application.routes.default_url_options[:host] = ENV.fetch("APP_HOST", "https://okaimonote.com")
+  # :host にはプロトコルを含めない（含めると url_for で二重プロトコルURLになる）
+  Rails.application.routes.default_url_options[:host] = ENV.fetch("APP_HOST", "okaimonote.com")
 
 
   # Enable DNS rebinding protection and other `Host` header attacks.

--- a/frontend/src/app/admin/abnormal_prices/page.tsx
+++ b/frontend/src/app/admin/abnormal_prices/page.tsx
@@ -6,11 +6,12 @@ import { apiFetch } from "@/lib/api";
 type AbnormalRecord = {
   id: number;
   price: number;
-  product_name: string;
+  avg_price: number | null;
+  deviation: number | null;
+  product_name: string | null;
   shop_name: string | null;
   user_nickname: string | null;
   purchased_at: string;
-  z_score?: number;
 };
 
 export default function AdminAbnormalPricesPage() {


### PR DESCRIPTION
## Summary

調査で判明したフロント・バック連携バグを一括修正。

- **remember_me**: `POST /api/v1/sessions` で `remember_me=1` を受け取っても無視されていた → `user.remember_me!` を呼び出し90日維持を有効化
- **BAN ユーザー（API）**: API リクエスト時に `reject_banned_user` が HTML リダイレクト（302）を返していた → `BaseController` に `reject_banned_user_api` を追加して JSON 403 を返すよう変更
- **BAN ユーザー（iOS）**: iOS トークン認証で BAN ユーザーがセッション確立できていた → `sign_in` 前に `status_banned?` チェックを追加
- **APP_HOST**: デフォルト値に `https://` プロトコルが含まれており `url_for` で二重プロトコル URL が生成される恐れがあった → `"okaimonote.com"` に修正
- **after_update_path_for**: プロフィール更新後の遷移先が Rails ビュー `/profile` になっていた → `FRONTEND_URL/profile` へ変更
- **アカウント削除**: 削除後に Rails の `/` にリダイレクトしていた → `FRONTEND_URL/login` へ変更
- **異常価格型定義**: フロントの型が `z_score` を期待していたがバックエンドは `avg_price`/`deviation` を返していた → フロント型をバックエンドのレスポンスに合わせて修正
- **.env.example**: 新規作成し `FRONTEND_URL` など必要な環境変数をドキュメント整備

## Test plan

- [ ] 「ログインを維持する」ON でログインし、しばらく後もセッションが継続されること
- [ ] BAN されたユーザーが API を叩くと JSON `{ "error": "..." }` で 403 が返ること（302 にならないこと）
- [ ] iOS トークン認証で BAN ユーザーがセッション確立できないこと
- [ ] パスワード・プロフィール変更後に Next.js の `/profile` ページに遷移すること
- [ ] アカウント削除後に Next.js の `/login` ページに遷移すること
- [ ] 管理画面の異常価格一覧が正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)