### PR TITLE
「戻る」ボタンを Next.js に統一し、ホームサマリーを初期表示する

### DIFF
--- a/app/views/settings/contact.html.erb
+++ b/app/views/settings/contact.html.erb
@@ -43,8 +43,9 @@
     <% end %>
 
     <div class="text-center mt-8">
+      <% frontend_url = ENV.fetch("FRONTEND_URL", "https://www.okaimonote.com") %>
       <%= link_to '戻る',
-            user_signed_in? ? settings_path : root_path,
+            user_signed_in? ? "#{frontend_url}/settings" : frontend_url,
             class: "inline-block bg-gray-200 text-gray-700 px-6 py-2 md:px-8 md:py-3 rounded-full shadow hover:bg-gray-300 transition duration-200 text-base md:text-lg" %>
     </div>
   </div>

--- a/app/views/settings/privacy.html.erb
+++ b/app/views/settings/privacy.html.erb
@@ -99,9 +99,10 @@
       </section>
     </div>
 
+    <% frontend_url = ENV.fetch("FRONTEND_URL", "https://www.okaimonote.com") %>
     <div class="text-center mt-12">
       <%= link_to '戻る',
-            user_signed_in? ? settings_path : root_path,
+            user_signed_in? ? "#{frontend_url}/settings" : frontend_url,
         class: "inline-block bg-brand text-white px-6 md:px-8 py-2 md:py-3 rounded-full shadow hover:bg-orange-600 transition duration-200 text-base md:text-lg" %>
     </div>
   </div>

--- a/app/views/settings/terms.html.erb
+++ b/app/views/settings/terms.html.erb
@@ -96,9 +96,10 @@
       </section>
     </div>
 
+    <% frontend_url = ENV.fetch("FRONTEND_URL", "https://www.okaimonote.com") %>
     <div class="text-center mt-12">
       <%= link_to '戻る',
-            user_signed_in? ? settings_path : root_path,
+            user_signed_in? ? "#{frontend_url}/settings" : frontend_url,
         class: "inline-block bg-brand text-white px-6 py-2 md:px-8 md:py-3 rounded-full shadow hover:bg-orange-600 transition duration-200 text-base md:text-lg" %>
     </div>
   </div>

--- a/app/views/settings/thank_you.html.erb
+++ b/app/views/settings/thank_you.html.erb
@@ -6,8 +6,9 @@
       担当者より順次ご連絡いたします。
     </p>
 
+    <% frontend_url = ENV.fetch("FRONTEND_URL", "https://www.okaimonote.com") %>
     <%= link_to "戻る",
-          user_signed_in? ? settings_path : root_path,
+          user_signed_in? ? "#{frontend_url}/settings" : frontend_url,
       class: "inline-block bg-brand text-white px-6 md:px-8 py-2.5 md:py-3 rounded-full shadow hover:bg-orange-600 transition duration-200 text-sm md:text-base font-semibold" %>
   </div>
 </div>

--- a/frontend/src/app/home/page.tsx
+++ b/frontend/src/app/home/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import useSWR from "swr";
 import { useHome, type HomeSearchParams } from "@/hooks/useHome";
 import { usePriceSummary } from "@/hooks/useHome";
@@ -238,6 +238,13 @@ export default function HomePage() {
     null
   );
   const { summary } = usePriceSummary(selectedProductId);
+
+  // 初回データ取得後、先頭レコードの商品を自動選択してサマリーを表示する
+  useEffect(() => {
+    if (selectedProductId === null && priceRecords.length > 0) {
+      setSelectedProductId(priceRecords[0].product_id);
+    }
+  }, [priceRecords, selectedProductId]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary

- お問い合わせ・利用規約・プライバシーポリシー・送信完了画面の「戻る」ボタンが旧 Rails 画面に遷移していたバグを修正
- ホーム画面でページロード時にサマリーカードが表示されなかった問題を修正

## 変更内容

### 「戻る」ボタン修正（Closes #229）
`contact.html.erb` / `terms.html.erb` / `privacy.html.erb` / `thank_you.html.erb` の「戻る」リンクを `FRONTEND_URL` ベースに変更：
- ログイン中 → `FRONTEND_URL/settings`（Next.js 設定画面）
- 未ログイン → `FRONTEND_URL`（Next.js タイトル画面）

### ホームサマリー初期表示（Closes #230）
`frontend/src/app/home/page.tsx` に `useEffect` を追加し、初回データ取得後に先頭レコードの商品を自動選択してサマリーカードを表示。

## Test plan

- [ ] 未ログインでタイトル画面から「お問い合わせ」→「戻る」で `www.okaimonote.com/` に戻る
- [ ] ログイン中に設定画面から「お問い合わせ」→「戻る」で `www.okaimonote.com/settings` に戻る
- [ ] 利用規約・プライバシーポリシーも同様に動作する
- [ ] お問い合わせ送信後の完了画面でも同様に動作する
- [ ] ホーム画面を開くと最初の価格記録の商品サマリーが自動表示される
- [ ] 価格記録がない場合はサマリーカードが表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)