### PR TITLE
ガイド・新規登録・PW リセット・管理オートコンプリートを Next.js に実装

### DIFF
--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -1,0 +1,39 @@
+# パスワードリセットを JSON API として提供するコントローラー
+module Api
+  module V1
+    class PasswordsController < BaseController
+      # パスワードリセットは未認証で行う
+      skip_before_action :authenticate_user!
+      skip_before_action :reject_banned_user_api
+
+      # POST /api/v1/passwords
+      # パスワードリセットメールを送信する
+      def create
+        user = User.find_by(email: params[:email])
+
+        if user
+          user.send_reset_password_instructions
+        end
+
+        # ユーザーの有無に関わらず同じメッセージを返す（メール存在確認攻撃を防ぐ）
+        render json: { message: "パスワードリセットのメールを送信しました。メールをご確認ください。" }
+      end
+
+      # PATCH /api/v1/passwords
+      # リセットトークンを使ってパスワードを変更する
+      def update
+        user = User.reset_password_by_token(
+          reset_password_token: params[:reset_password_token],
+          password: params[:password],
+          password_confirmation: params[:password_confirmation]
+        )
+
+        if user.errors.empty?
+          render json: { message: "パスワードを変更しました。ログインしてください。" }
+        else
+          render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -1,0 +1,28 @@
+# 新規会員登録を JSON API として提供するコントローラー
+module Api
+  module V1
+    class RegistrationsController < BaseController
+      # 登録は未認証で行う
+      skip_before_action :authenticate_user!
+      skip_before_action :reject_banned_user_api
+
+      # POST /api/v1/registrations
+      # メールアドレス・パスワード・ニックネームでユーザーを新規作成する
+      def create
+        user = User.new(registration_params)
+
+        if user.save
+          render json: { message: "確認メールを送信しました。メールをご確認ください。" }, status: :created
+        else
+          render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def registration_params
+        params.permit(:email, :password, :password_confirmation, :nickname)
+      end
+    end
+  end
+end

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -17,8 +17,9 @@
 
   <!-- ボタン -->
   <div style="text-align: center; margin: 24px 0;">
+    <% frontend_url = ENV.fetch("FRONTEND_URL", "https://www.okaimonote.com") %>
     <%= link_to 'パスワードを再設定する',
-                edit_password_url(@resource, reset_password_token: @token),
+                "#{frontend_url}/reset-password?reset_password_token=#{@token}",
                 style: "background-color: #F97316; color: #fff; text-decoration: none; padding: 12px 24px; border-radius: 9999px; font-weight: bold; display: inline-block;" %>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,9 +98,12 @@ Rails.application.routes.draw do
   # Next.jsフロントエンド向けJSON API
   namespace :api do
     namespace :v1 do
-      get    "me",       to: "auth#me"
-      post   "sessions", to: "sessions#create"
-      delete "sessions", to: "sessions#destroy"
+      get    "me",          to: "auth#me"
+      post   "sessions",    to: "sessions#create"
+      delete "sessions",    to: "sessions#destroy"
+      post   "registrations", to: "registrations#create"
+      post   "passwords",   to: "passwords#create"
+      patch  "passwords",   to: "passwords#update"
       patch "profile", to: "profile#update"
 
       # ショッピングリスト

--- a/frontend/src/app/admin/stats/page.tsx
+++ b/frontend/src/app/admin/stats/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import useSWR from "swr";
 import { apiFetch } from "@/lib/api";
 
@@ -12,6 +12,87 @@ type StatsData = {
   top_products_by_records: { name: string; count: number }[];
   top_shops: { name: string; count: number }[];
 };
+
+/** テキスト入力 + オートコンプリートドロップダウン */
+function AutocompleteInput({
+  value,
+  onChange,
+  placeholder,
+  autocompleteUrl,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder: string;
+  autocompleteUrl: (q: string) => string;
+}) {
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [open, setOpen] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // 入力変化時にデバウンスして API を呼ぶ
+  const handleChange = useCallback(
+    (v: string) => {
+      onChange(v);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (!v.trim()) {
+        setSuggestions([]);
+        setOpen(false);
+        return;
+      }
+      timerRef.current = setTimeout(async () => {
+        try {
+          const res = await apiFetch<string[]>(autocompleteUrl(v));
+          setSuggestions(res);
+          setOpen(res.length > 0);
+        } catch {
+          setSuggestions([]);
+          setOpen(false);
+        }
+      }, 300);
+    },
+    [onChange, autocompleteUrl]
+  );
+
+  // ラッパー外クリックでドロップダウンを閉じる
+  useEffect(() => {
+    function handleOutside(e: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleOutside);
+    return () => document.removeEventListener("mousedown", handleOutside);
+  }, []);
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => handleChange(e.target.value)}
+        placeholder={placeholder}
+        className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-orange-400 outline-none w-full"
+      />
+      {open && (
+        <ul className="absolute z-10 top-full left-0 mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-md max-h-48 overflow-y-auto">
+          {suggestions.map((s) => (
+            <li
+              key={s}
+              onMouseDown={() => {
+                onChange(s);
+                setOpen(false);
+              }}
+              className="px-3 py-2 text-sm cursor-pointer hover:bg-orange-50"
+            >
+              {s}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
 
 export default function AdminStatsPage() {
   const [keyword, setKeyword] = useState("");
@@ -39,13 +120,29 @@ export default function AdminStatsPage() {
       <h1 className="text-2xl font-bold text-gray-800">価格統計</h1>
 
       <form onSubmit={handleSearch} className="bg-white rounded-xl shadow border border-gray-100 p-5 flex flex-wrap gap-3">
-        <input type="text" value={keyword} onChange={(e) => setKeyword(e.target.value)}
-          placeholder="商品名" className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-orange-400 outline-none" />
-        <input type="text" value={shopName} onChange={(e) => setShopName(e.target.value)}
-          placeholder="店舗名" className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-orange-400 outline-none" />
-        <input type="text" value={pref} onChange={(e) => setPref(e.target.value)}
-          placeholder="都道府県" className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-orange-400 outline-none" />
-        <button type="submit" className="bg-orange-500 hover:bg-orange-600 text-white text-sm font-semibold px-4 py-2 rounded-lg transition">
+        <AutocompleteInput
+          value={keyword}
+          onChange={setKeyword}
+          placeholder="商品名"
+          autocompleteUrl={(q) => `/api/v1/admin/stats/autocomplete_products?q=${encodeURIComponent(q)}`}
+        />
+        <AutocompleteInput
+          value={shopName}
+          onChange={setShopName}
+          placeholder="店舗名"
+          autocompleteUrl={(q) => `/api/v1/admin/stats/autocomplete_shops?q=${encodeURIComponent(q)}`}
+        />
+        <input
+          type="text"
+          value={pref}
+          onChange={(e) => setPref(e.target.value)}
+          placeholder="都道府県"
+          className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-orange-400 outline-none"
+        />
+        <button
+          type="submit"
+          className="bg-orange-500 hover:bg-orange-600 text-white text-sm font-semibold px-4 py-2 rounded-lg transition"
+        >
           検索
         </button>
       </form>

--- a/frontend/src/app/forgot-password/page.tsx
+++ b/frontend/src/app/forgot-password/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+
+/** パスワードリセットメール送信ページ（認証不要） */
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [done, setDone] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setIsSubmitting(true);
+    try {
+      await apiFetch("/api/v1/passwords", {
+        method: "POST",
+        body: JSON.stringify({ email }),
+      });
+    } finally {
+      // メールが存在しない場合も同じ画面を表示してメール存在確認を防ぐ
+      setDone(true);
+      setIsSubmitting(false);
+    }
+  }
+
+  if (done) {
+    return (
+      <div className="min-h-screen bg-[#FFF9F3] flex items-center justify-center px-4">
+        <div className="bg-white rounded-2xl shadow-lg border border-orange-100 p-8 w-full max-w-md text-center">
+          <p className="text-4xl mb-4">✉️</p>
+          <h2 className="text-xl font-bold text-orange-500 mb-3">メールを送信しました</h2>
+          <p className="text-sm text-gray-600 mb-6">
+            登録済みのメールアドレスにパスワードリセット用のリンクを送信しました。
+            メールをご確認ください。
+          </p>
+          <Link
+            href="/login"
+            className="inline-block bg-orange-500 hover:bg-orange-600 text-white font-bold py-2.5 px-6 rounded-full shadow-md transition"
+          >
+            ログイン画面へ
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[#FFF9F3] flex items-center justify-center px-4 sm:px-6 py-10">
+      <div className="bg-white rounded-2xl shadow-lg border border-orange-100 p-6 sm:p-8 w-full max-w-md">
+        <h2 className="text-xl sm:text-2xl font-bold text-center text-orange-500 mb-2">
+          パスワードをお忘れですか？
+        </h2>
+        <p className="text-sm text-gray-500 text-center mb-6">
+          登録済みのメールアドレスを入力してください。
+          パスワードリセット用のリンクをお送りします。
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              メールアドレス
+            </label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoComplete="email"
+              placeholder="example@email.com"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 outline-none transition"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white font-bold py-2.5 rounded-full shadow-md transition active:scale-[0.98]"
+          >
+            {isSubmitting ? "送信中..." : "リセットメールを送る"}
+          </button>
+        </form>
+
+        <div className="text-center mt-6">
+          <Link href="/login" className="text-sm text-orange-500 hover:underline">
+            ログイン画面に戻る
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/guide/page.tsx
+++ b/frontend/src/app/guide/page.tsx
@@ -1,0 +1,86 @@
+import Link from "next/link";
+
+/** 使い方ガイドページ（認証不要） */
+export default function GuidePage() {
+  return (
+    <div className="min-h-screen bg-[#FFF9F3] text-gray-800 py-10 px-4 sm:px-6 md:px-10">
+      <div className="max-w-2xl mx-auto bg-white rounded-2xl shadow-lg p-6 sm:p-8 border border-orange-100">
+        <h1 className="text-2xl font-bold text-center text-orange-500 mb-8">
+          おかいもノート 使い方ガイド
+        </h1>
+
+        <section className="mb-8">
+          <h2 className="text-lg font-semibold text-gray-700 mb-2">
+            1. 価格を登録する
+          </h2>
+          <p className="text-gray-600 text-sm leading-relaxed">
+            フッター中央の「＋」ボタンから価格を登録できます。
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-base sm:text-lg font-semibold text-gray-700 mb-2">
+            2. 価格サマリーを見る
+          </h2>
+          <p className="text-gray-600 text-sm leading-relaxed">
+            ホーム画面の履歴カードをタップすると、その商品の価格サマリーが表示されます。
+            最安値・最高値・平均価格・前回購入価格を簡単に確認できます。
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-base sm:text-lg font-semibold text-gray-700 mb-2">
+            3. お店リストを管理する
+          </h2>
+          <p className="text-gray-600 text-sm leading-relaxed">
+            「お店リスト」では、よく使うお店を登録できます。
+            新しくお店を追加すると、価格登録時にその店舗を選択できるようになります。
+            既に登録済みの商品も、編集画面から購入店舗を後から設定・変更可能です。
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-base sm:text-lg font-semibold text-gray-700 mb-2">
+            4. カテゴリーと商品を整理する
+          </h2>
+          <p className="text-gray-600 text-sm leading-relaxed">
+            「カテゴリーリスト」からカテゴリーを追加・編集・削除できます。
+            各カテゴリーに紐づいた商品は「商品リスト」から編集や削除も可能です。
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-base sm:text-lg font-semibold text-gray-700 mb-2">
+            5. 買い物リスト機能を使う
+          </h2>
+          <p className="text-gray-600 text-sm leading-relaxed">
+            「買い物リスト」では、必要なものをリスト化して管理できます。
+            商品名の右側にあるアイコンから、編集や購入済みへの切り替えが可能です。
+            買い物の進行状況がひと目で分かるため、買い忘れ防止にも役立ちます。
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-base sm:text-lg font-semibold text-gray-700 mb-2">
+            6. ワンポイント
+          </h2>
+          <ul className="list-disc pl-5 text-sm text-gray-600 space-y-1 leading-relaxed">
+            <li>トップページの価格履歴は新しい順に5件まで表示されます。</li>
+            <li>登録後の編集や削除は、各詳細ページの「︙」ボタンから行えます。</li>
+            <li>メモ欄には自由にコメントを残せるので、特売情報などを記録しておくと便利です。</li>
+            <li>よく使う商品名やお店は、入力時に候補が表示されるため素早く登録できます。</li>
+          </ul>
+        </section>
+
+        <div className="text-center mt-10">
+          <Link
+            href="/"
+            className="inline-block bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2.5 px-6 rounded-full shadow-md transition"
+          >
+            タイトルに戻る
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, type FormEvent } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { apiFetch } from "@/lib/api";
 
@@ -87,12 +88,12 @@ export default function LoginPage() {
               />
               <span>ログインを維持する</span>
             </label>
-            <a
-              href={`${API_BASE}/users/password/new`}
+            <Link
+              href="/forgot-password"
               className="text-orange-500 hover:underline"
             >
               パスワードをお忘れですか？
-            </a>
+            </Link>
           </div>
 
           <button
@@ -141,12 +142,12 @@ export default function LoginPage() {
         {/* 新規登録リンク */}
         <div className="text-center mt-6">
           <p className="text-sm text-gray-600 mb-2">まだアカウントをお持ちでない方</p>
-          <a
-            href={`${API_BASE}/users/sign_up`}
+          <Link
+            href="/signup"
             className="inline-block text-orange-500 font-semibold hover:underline"
           >
             新規登録はこちら
-          </a>
+          </Link>
         </div>
       </div>
     </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -44,24 +44,24 @@ export default function TitlePage() {
 
         {/* ボタン */}
         <div className="flex flex-col gap-4 mt-8 animate-slide-up">
-          <a
-            href={`${API_BASE}/users/sign_up`}
+          <Link
+            href="/signup"
             className="w-56 sm:w-60 mx-auto text-white bg-orange-500 hover:bg-orange-600 font-bold py-2.5 rounded-full shadow transition text-center block"
           >
             新規登録
-          </a>
+          </Link>
           <Link
             href="/login"
             className="w-56 sm:w-60 mx-auto text-orange-500 bg-white border border-orange-400 hover:bg-orange-50 font-bold py-2.5 rounded-full shadow transition text-center block"
           >
             ログイン
           </Link>
-          <a
-            href={`${API_BASE}/guide`}
+          <Link
+            href="/guide"
             className="text-sm text-orange-500 hover:text-orange-600 underline underline-offset-2 transition mt-2"
           >
             使い方ガイドを見る
-          </a>
+          </Link>
         </div>
 
         {/* フッターリンク */}

--- a/frontend/src/app/reset-password/page.tsx
+++ b/frontend/src/app/reset-password/page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState, type FormEvent, Suspense } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { apiFetch } from "@/lib/api";
+
+/** パスワード再設定ページ（メール内リンクから遷移・認証不要）
+ *  URL: /reset-password?reset_password_token=xxx
+ */
+function ResetPasswordForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("reset_password_token") ?? "";
+
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [errors, setErrors] = useState<string[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setErrors([]);
+    setIsSubmitting(true);
+
+    try {
+      await apiFetch("/api/v1/passwords", {
+        method: "PATCH",
+        body: JSON.stringify({
+          reset_password_token: token,
+          password,
+          password_confirmation: passwordConfirmation,
+        }),
+      });
+      router.replace("/login?reset=success");
+    } catch (err: unknown) {
+      const apiErr = err as { errors?: string[]; message?: string };
+      if (apiErr.errors && apiErr.errors.length > 0) {
+        setErrors(apiErr.errors);
+      } else {
+        setErrors([apiErr.message ?? "パスワードの変更に失敗しました。リンクの有効期限が切れている可能性があります。"]);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (!token) {
+    return (
+      <div className="min-h-screen bg-[#FFF9F3] flex items-center justify-center px-4">
+        <div className="bg-white rounded-2xl shadow-lg border border-orange-100 p-8 w-full max-w-md text-center">
+          <p className="text-gray-600 mb-4">無効なリンクです。</p>
+          <Link href="/forgot-password" className="text-orange-500 hover:underline text-sm">
+            もう一度リセットメールを送る
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[#FFF9F3] flex items-center justify-center px-4 sm:px-6 py-10">
+      <div className="bg-white rounded-2xl shadow-lg border border-orange-100 p-6 sm:p-8 w-full max-w-md">
+        <h2 className="text-xl sm:text-2xl font-bold text-center text-orange-500 mb-6">
+          新しいパスワードを設定
+        </h2>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {errors.length > 0 && (
+            <ul className="text-sm text-red-600 bg-red-50 border-l-4 border-red-400 rounded-xl px-3 py-2 space-y-1">
+              {errors.map((e, i) => <li key={i}>{e}</li>)}
+            </ul>
+          )}
+
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              新しいパスワード
+            </label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              autoComplete="new-password"
+              placeholder="8文字以上"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 outline-none transition"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              新しいパスワード（確認）
+            </label>
+            <input
+              type="password"
+              value={passwordConfirmation}
+              onChange={(e) => setPasswordConfirmation(e.target.value)}
+              required
+              autoComplete="new-password"
+              placeholder="もう一度入力してください"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 outline-none transition"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white font-bold py-2.5 rounded-full shadow-md transition active:scale-[0.98]"
+          >
+            {isSubmitting ? "変更中..." : "パスワードを変更する"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense>
+      <ResetPasswordForm />
+    </Suspense>
+  );
+}

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { apiFetch } from "@/lib/api";
+
+/** 新規会員登録ページ（認証不要） */
+export default function SignupPage() {
+  const [nickname, setNickname] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [errors, setErrors] = useState<string[]>([]);
+  const [done, setDone] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setErrors([]);
+    setIsSubmitting(true);
+
+    try {
+      await apiFetch("/api/v1/registrations", {
+        method: "POST",
+        body: JSON.stringify({ nickname, email, password, password_confirmation: passwordConfirmation }),
+      });
+      setDone(true);
+    } catch (err: unknown) {
+      const apiErr = err as { errors?: string[]; message?: string };
+      if (apiErr.errors && apiErr.errors.length > 0) {
+        setErrors(apiErr.errors);
+      } else {
+        setErrors([apiErr.message ?? "登録に失敗しました。もう一度お試しください。"]);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (done) {
+    return (
+      <div className="min-h-screen bg-[#FFF9F3] flex items-center justify-center px-4">
+        <div className="bg-white rounded-2xl shadow-lg border border-orange-100 p-8 w-full max-w-md text-center">
+          <p className="text-4xl mb-4">✉️</p>
+          <h2 className="text-xl font-bold text-orange-500 mb-3">確認メールを送信しました</h2>
+          <p className="text-sm text-gray-600 mb-6">
+            ご登録のメールアドレスに確認メールを送信しました。
+            メール内のリンクをクリックして登録を完了してください。
+          </p>
+          <Link
+            href="/login"
+            className="inline-block bg-orange-500 hover:bg-orange-600 text-white font-bold py-2.5 px-6 rounded-full shadow-md transition"
+          >
+            ログイン画面へ
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[#FFF9F3] flex items-center justify-center px-4 sm:px-6 py-10">
+      <div className="bg-white rounded-2xl shadow-lg border border-orange-100 p-6 sm:p-8 w-full max-w-md">
+        {/* ロゴ */}
+        <div className="flex justify-center mb-4">
+          <Image
+            src="/images/okaimonote_logo.png"
+            alt="おかいもノート"
+            width={80}
+            height={80}
+            className="rounded-xl"
+          />
+        </div>
+        <h2 className="text-xl sm:text-2xl font-bold text-center text-orange-500 mb-6">
+          新規登録
+        </h2>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {errors.length > 0 && (
+            <ul className="text-sm text-red-600 bg-red-50 border-l-4 border-red-400 rounded-xl px-3 py-2 space-y-1">
+              {errors.map((e, i) => <li key={i}>{e}</li>)}
+            </ul>
+          )}
+
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              ニックネーム
+            </label>
+            <input
+              type="text"
+              value={nickname}
+              onChange={(e) => setNickname(e.target.value)}
+              required
+              maxLength={20}
+              placeholder="おかいも太郎"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 outline-none transition"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              メールアドレス
+            </label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoComplete="email"
+              placeholder="example@email.com"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 outline-none transition"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              パスワード
+            </label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              autoComplete="new-password"
+              placeholder="8文字以上"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 outline-none transition"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              パスワード（確認）
+            </label>
+            <input
+              type="password"
+              value={passwordConfirmation}
+              onChange={(e) => setPasswordConfirmation(e.target.value)}
+              required
+              autoComplete="new-password"
+              placeholder="もう一度入力してください"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 outline-none transition"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white font-bold py-2.5 rounded-full shadow-md transition active:scale-[0.98]"
+          >
+            {isSubmitting ? "登録中..." : "登録する"}
+          </button>
+        </form>
+
+        <div className="text-center mt-6">
+          <p className="text-sm text-gray-600 mb-1">すでにアカウントをお持ちの方</p>
+          <Link href="/login" className="text-orange-500 font-semibold hover:underline text-sm">
+            ログインはこちら
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -5,7 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
 
 /** 認証不要のパス一覧 */
-const PUBLIC_PATHS = ["/", "/login"];
+const PUBLIC_PATHS = ["/", "/login", "/guide", "/signup", "/forgot-password", "/reset-password"];
 
 /** 認証状態を監視し、未認証時はログイン画面へリダイレクトする共通プロバイダー */
 export function AuthProvider({ children }: { children: React.ReactNode }) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -40,6 +40,7 @@ export async function apiFetch<T>(
     const error = await res.json().catch(() => ({ error: res.statusText }));
     throw Object.assign(new Error(error.error ?? res.statusText), {
       status: res.status,
+      errors: error.errors ?? [],
     });
   }
 


### PR DESCRIPTION
## Summary

- 使い方ガイドページを Next.js に移植し、タイトル画面リンクを内部リンク化
- 管理画面の価格統計ページに商品・店舗名のオートコンプリートを追加
- 新規会員登録フォームを Next.js に実装（Rails API エンドポイント追加）
- パスワードリセットフローを Next.js に実装（Rails API エンドポイント追加）

## 変更内容

### ガイドページ（Closes #232）
- `frontend/src/app/guide/page.tsx` を新規作成（Rails ERB と同内容）
- タイトル画面の「使い方ガイドを見る」を `<Link href="/guide">` に変更

### 管理画面オートコンプリート（Closes #233）
- `admin/stats/page.tsx` の商品名・店舗名入力に `AutocompleteInput` コンポーネントを追加
- 入力 300ms 後に `/api/v1/admin/stats/autocomplete_products|shops?q=xxx` を呼び出してドロップダウン表示

### 新規会員登録（Closes #234）
- `POST /api/v1/registrations` エンドポイントを追加（Devise `User.new` → save）
- `/signup/page.tsx` を新規作成。バリデーションエラー表示・登録完了後のメッセージ表示
- タイトル画面・ログイン画面の新規登録リンクを `/signup` に変更

### パスワードリセット（Closes #235）
- `POST /api/v1/passwords`（リセットメール送信）・`PATCH /api/v1/passwords`（パスワード変更）を追加
- `/forgot-password/page.tsx`・`/reset-password/page.tsx` を新規作成
- ログイン画面の「パスワードをお忘れですか？」を `/forgot-password` に変更
- パスワードリセットメールのリンク先を `FRONTEND_URL/reset-password?reset_password_token=xxx` に変更
- `AuthProvider` の `PUBLIC_PATHS` に全新規ページを追加
- `apiFetch` のエラーオブジェクトに `errors` 配列を付与

## Test plan

- [ ] タイトル画面「使い方ガイドを見る」→ Next.js ガイドページが表示される
- [ ] 管理画面 価格統計の商品名フィールドで入力するとオートコンプリート候補が表示される
- [ ] タイトル画面「新規登録」→ `/signup` が表示される
- [ ] 新規登録フォームでエラー時にメッセージが表示される
- [ ] 新規登録成功後に確認メールが届く
- [ ] ログイン画面「パスワードをお忘れですか？」→ `/forgot-password` が表示される
- [ ] リセットメールのリンクを開くと `/reset-password?reset_password_token=xxx` に遷移する
- [ ] パスワード変更後にログイン画面へリダイレクトされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)