### PR TITLE
未実装ページを Next.js に移行し API を追加する

### DIFF
--- a/app/controllers/api/v1/account_controller.rb
+++ b/app/controllers/api/v1/account_controller.rb
@@ -1,0 +1,15 @@
+# アカウント削除 API
+module Api
+  module V1
+    class AccountController < BaseController
+      # DELETE /api/v1/account
+      # ログアウト後にアカウントを削除する
+      def destroy
+        user = current_user
+        sign_out user
+        user.destroy!
+        render json: { message: "アカウントを削除しました" }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/settings_controller.rb
+++ b/app/controllers/api/v1/admin/settings_controller.rb
@@ -1,0 +1,16 @@
+# 管理画面：設定情報 API
+module Api
+  module V1
+    module Admin
+      class SettingsController < BaseController
+        # GET /api/v1/admin/settings
+        # サービス設定値を返す
+        def show
+          render json: {
+            max_family_members: Family::MAX_MEMBERS
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/contacts_controller.rb
+++ b/app/controllers/api/v1/contacts_controller.rb
@@ -1,0 +1,28 @@
+# お問い合わせ送信 API
+module Api
+  module V1
+    class ContactsController < BaseController
+      skip_before_action :authenticate_user!
+      skip_before_action :reject_banned_user_api
+
+      # POST /api/v1/contacts
+      # お問い合わせを保存してメール送信する
+      def create
+        @contact = Contact.new(
+          nickname: params[:nickname],
+          email: params[:email],
+          body: params[:message],
+          status: :unread
+        )
+
+        if @contact.save
+          ContactMailer.contact_email(params[:nickname], params[:email], params[:message]).deliver_now
+          ContactMailer.auto_reply(params[:nickname], params[:email], params[:message]).deliver_now
+          render json: { message: "お問い合わせを受け付けました" }, status: :created
+        else
+          render json: { errors: @contact.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/profile_controller.rb
+++ b/app/controllers/api/v1/profile_controller.rb
@@ -18,6 +18,35 @@ module Api
         end
       end
 
+      # PATCH /api/v1/profile/email
+      # メールアドレスを変更する（現在のパスワードで本人確認）
+      def update_email
+        if current_user.update_with_password(
+          email: params[:email],
+          current_password: params[:current_password]
+        )
+          render json: { message: "メールアドレスを更新しました" }
+        else
+          render json: { errors: current_user.errors.full_messages },
+                 status: :unprocessable_entity
+        end
+      end
+
+      # PATCH /api/v1/profile/password
+      # パスワードを変更する（現在のパスワードで本人確認）
+      def update_password
+        if current_user.update_with_password(
+          password: params[:password],
+          password_confirmation: params[:password_confirmation],
+          current_password: params[:current_password]
+        )
+          render json: { message: "パスワードを変更しました" }
+        else
+          render json: { errors: current_user.errors.full_messages },
+                 status: :unprocessable_entity
+        end
+      end
+
       private
 
       def profile_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,7 +104,11 @@ Rails.application.routes.draw do
       post   "registrations", to: "registrations#create"
       post   "passwords",   to: "passwords#create"
       patch  "passwords",   to: "passwords#update"
-      patch "profile", to: "profile#update"
+      patch "profile",          to: "profile#update"
+      patch "profile/email",    to: "profile#update_email"
+      patch "profile/password", to: "profile#update_password"
+      delete "account",         to: "account#destroy"
+      post   "contacts",        to: "contacts#create"
 
       # ショッピングリスト
       # ショッピングリスト (singular resource: /api/v1/shopping_list)
@@ -167,6 +171,7 @@ Rails.application.routes.draw do
         get  "stats/autocomplete_shops",     to: "stats#autocomplete_shops"
         get  "services",         to: "services#index"
         get  "abnormal_prices",  to: "abnormal_prices#index"
+        get  "settings",         to: "settings#show"
       end
     end
   end

--- a/frontend/src/app/account/delete/page.tsx
+++ b/frontend/src/app/account/delete/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { apiFetch } from "@/lib/api";
+import { useFlash } from "@/contexts/FlashContext";
+
+/** アカウント削除確認ページ */
+export default function AccountDeletePage() {
+  const router = useRouter();
+  const { flash } = useFlash();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
+
+  async function handleDelete() {
+    if (!confirmed) return;
+    setIsDeleting(true);
+    try {
+      await apiFetch("/api/v1/account", { method: "DELETE" });
+      flash("notice", "アカウントを削除しました。ご利用ありがとうございました。");
+      router.replace("/login");
+    } catch {
+      flash("alert", "削除に失敗しました。もう一度お試しください。");
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-orange-50 py-10 px-4">
+      <div className="max-w-md mx-auto">
+        <h1 className="text-2xl font-bold text-center text-red-500 mb-8">
+          ⚠ アカウント削除
+        </h1>
+
+        <div className="bg-white rounded-2xl shadow border border-red-100 p-6 space-y-6">
+          <p className="text-sm text-gray-700 leading-relaxed">
+            アカウントを削除すると、登録した
+            <span className="font-semibold text-gray-900">商品・価格履歴・家族情報</span>
+            などのデータはすべて削除され、元に戻すことはできません。
+          </p>
+
+          <p className="text-sm text-gray-700 leading-relaxed">
+            <span className="font-semibold text-red-600">おかいもノートのアカウントを削除</span>
+            してもよろしいですか？
+          </p>
+
+          <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={confirmed}
+              onChange={(e) => setConfirmed(e.target.checked)}
+              className="w-4 h-4 rounded accent-red-500"
+            />
+            上記の内容を理解した上で削除します
+          </label>
+
+          <div className="space-y-3 pt-2">
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={!confirmed || isDeleting}
+              className="w-full bg-red-500 hover:bg-red-600 disabled:opacity-50 text-white font-semibold py-3 rounded-full shadow-md transition active:scale-[0.98]"
+            >
+              {isDeleting ? "削除中..." : "削除する"}
+            </button>
+
+            <Link
+              href="/settings"
+              className="block w-full text-center bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium py-3 rounded-full transition"
+            >
+              キャンセルして設定に戻る
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -12,6 +12,7 @@ const NAV_ITEMS = [
   { href: "/admin/stats", label: "価格統計" },
   { href: "/admin/abnormal_prices", label: "異常価格" },
   { href: "/admin/services", label: "サービス概要" },
+  { href: "/admin/settings", label: "設定" },
 ];
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {

--- a/frontend/src/app/admin/settings/page.tsx
+++ b/frontend/src/app/admin/settings/page.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import useSWR from "swr";
+import { apiFetch } from "@/lib/api";
+
+type AdminSettings = {
+  max_family_members: number;
+};
+
+const PLANNED_FEATURES = [
+  "無料プランの利用制限",
+  "統計表示期間の変更",
+  "エリア統計の表示制御",
+  "機能の一時停止（メンテナンス）",
+  "広告表示",
+  "課金設定(iOS対応後)",
+];
+
+/** 管理画面：設定ページ */
+export default function AdminSettingsPage() {
+  const { data, isLoading } = useSWR<AdminSettings>("/api/v1/admin/settings", (url: string) =>
+    apiFetch<AdminSettings>(url)
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-800 flex items-center gap-2">
+          <span className="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-orange-100 text-orange-500">
+            ⚙
+          </span>
+          設定
+        </h1>
+        <p className="text-sm text-gray-600 mt-2">
+          okaimonote の動作ルールを確認できます。現在は一部の設定のみ有効。
+        </p>
+      </div>
+
+      {/* 利用制限 */}
+      <section className="bg-white rounded-2xl shadow border border-orange-100 p-6 space-y-4">
+        <h2 className="text-lg font-bold text-gray-800 flex items-center gap-2">
+          👥 利用制限
+        </h2>
+
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-semibold text-gray-800">家族メンバーの上限</p>
+            <p className="text-xs text-gray-500 mt-1">1つのファミリーに参加できる最大人数</p>
+          </div>
+          <div className="text-right">
+            {isLoading ? (
+              <p className="text-xl font-bold text-gray-400">--</p>
+            ) : (
+              <p className="text-xl font-bold text-gray-800">{data?.max_family_members} 人</p>
+            )}
+            <p className="text-xs text-gray-400">※ 現在変更できません</p>
+          </div>
+        </div>
+      </section>
+
+      {/* 今後追加予定 */}
+      <section className="bg-gray-50 rounded-2xl border border-gray-200 p-6 space-y-4">
+        <h2 className="text-lg font-bold text-gray-700 flex items-center gap-2">
+          ⏳ 今後追加予定
+        </h2>
+        <ul className="text-sm text-gray-600 list-disc list-inside space-y-1">
+          {PLANNED_FEATURES.map((f) => (
+            <li key={f}>{f}</li>
+          ))}
+        </ul>
+        <p className="text-xs text-gray-400 mt-2">
+          ※ これらの設定は今後のアップデートで順次追加予定。
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/contact/page.tsx
+++ b/frontend/src/app/contact/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+
+/** お問い合わせページ（認証不要） */
+export default function ContactPage() {
+  const [nickname, setNickname] = useState("");
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+  const [done, setDone] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      await apiFetch("/api/v1/contacts", {
+        method: "POST",
+        body: JSON.stringify({ nickname, email, message }),
+      });
+      setDone(true);
+    } catch {
+      setError("送信に失敗しました。入力内容をご確認ください。");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (done) {
+    return (
+      <div className="min-h-screen bg-[#FFF9F3] flex items-center justify-center px-4">
+        <div className="bg-white rounded-2xl shadow-lg border border-orange-100 p-8 w-full max-w-md text-center">
+          <p className="text-4xl mb-4">✉️</p>
+          <h2 className="text-xl font-bold text-orange-500 mb-3">お問い合わせを送信しました</h2>
+          <p className="text-sm text-gray-600 mb-6">
+            お問い合わせありがとうございます。内容を確認の上、ご連絡いたします。
+          </p>
+          <Link
+            href="/settings"
+            className="inline-block bg-orange-500 hover:bg-orange-600 text-white font-bold py-2.5 px-6 rounded-full shadow-md transition"
+          >
+            設定に戻る
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[#FFF9F3] flex items-center justify-center px-4 sm:px-6 py-10">
+      <div className="bg-white rounded-2xl shadow-lg border border-orange-100 p-6 sm:p-8 w-full max-w-md">
+        <h1 className="text-xl sm:text-2xl font-bold text-center text-orange-500 mb-6">
+          お問い合わせ
+        </h1>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <p className="text-sm text-red-600 bg-red-50 border-l-4 border-red-400 rounded-xl px-3 py-2">
+              {error}
+            </p>
+          )}
+
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              ニックネーム
+            </label>
+            <input
+              type="text"
+              value={nickname}
+              onChange={(e) => setNickname(e.target.value)}
+              required
+              placeholder="例：おかいも太郎"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 outline-none transition"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              メールアドレス
+            </label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              placeholder="例：sample@email.com"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 outline-none transition"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">
+              お問い合わせ内容
+            </label>
+            <textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              required
+              rows={6}
+              placeholder="内容を入力してください"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 outline-none transition"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white font-bold py-2.5 rounded-full shadow-md transition active:scale-[0.98]"
+          >
+            {isSubmitting ? "送信中..." : "送信する"}
+          </button>
+        </form>
+
+        <div className="text-center mt-6">
+          <Link href="/settings" className="text-sm text-orange-500 hover:underline">
+            設定に戻る
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/lists/page.tsx
+++ b/frontend/src/app/lists/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Link from "next/link";
+
+/** 登録リストページ - カテゴリー・お店へのナビゲーション */
+export default function ListsPage() {
+  return (
+    <div className="min-h-screen bg-orange-50 py-10 pb-24 px-4">
+      <div className="max-w-md mx-auto">
+        <h1 className="text-2xl font-bold text-center text-orange-500 mb-8">
+          登録リスト
+        </h1>
+
+        <div className="bg-white rounded-2xl shadow border border-orange-100 overflow-hidden">
+          <Link
+            href="/categories"
+            className="flex justify-between items-center px-5 py-4 border-b border-gray-100 hover:bg-orange-50 transition"
+          >
+            <span className="text-gray-800 font-semibold">📂 カテゴリーリスト</span>
+            <span className="text-gray-400">›</span>
+          </Link>
+          <Link
+            href="/shops"
+            className="flex justify-between items-center px-5 py-4 hover:bg-orange-50 transition"
+          >
+            <span className="text-gray-800 font-semibold">🏪 お店リスト</span>
+            <span className="text-gray-400">›</span>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/privacy/page.tsx
+++ b/frontend/src/app/privacy/page.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import Link from "next/link";
+
+/** プライバシーポリシーページ（認証不要） */
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-[#FFF9F3] py-10 px-4 flex justify-center">
+      <div className="w-full max-w-3xl bg-white rounded-2xl shadow-lg border border-orange-100 p-8 md:p-12">
+        <h1 className="text-2xl md:text-3xl font-bold text-center text-orange-500 mb-10">
+          プライバシーポリシー
+        </h1>
+
+        <div className="space-y-10 leading-relaxed text-base text-gray-800">
+          <section>
+            <h2 className="text-xl font-semibold text-orange-500 mb-3">お客様から取得する情報</h2>
+            <p>当サービスでは、お客様から以下の情報を取得する場合があります。</p>
+            <ul className="list-disc list-inside ml-4 space-y-1 text-gray-700 mt-2">
+              <li>氏名（ニックネームやペンネームを含む）</li>
+              <li>メールアドレス</li>
+              <li>生年月日または年齢</li>
+              <li>住所</li>
+              <li>プロフィール画像</li>
+              <li>外部サービスでの連携情報</li>
+              <li>Cookie（クッキー）や端末識別子</li>
+              <li>アクセス履歴、入力履歴、利用履歴など</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-orange-500 mb-3">お客様の情報を利用する目的</h2>
+            <p>取得した情報は、以下の目的で利用いたします。</p>
+            <ul className="list-disc list-inside ml-4 space-y-1 text-gray-700 mt-2">
+              <li>サービス利用登録および認証のため</li>
+              <li>お問い合わせ対応やご連絡のため</li>
+              <li>利用履歴や購入履歴の管理のため</li>
+              <li>サービス品質向上・改善のため</li>
+              <li>不正利用防止やセキュリティ向上のため</li>
+              <li>規約や法令に基づく対応のため</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-orange-500 mb-3">安全管理のための措置</h2>
+            <p>
+              当サービスでは、取得した情報の漏洩・滅失・毀損を防止するため、組織的・技術的な安全管理措置を講じています。具体的な措置内容については、法令に基づき個別に回答いたします。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-orange-500 mb-3">第三者提供</h2>
+            <p>
+              当サービスでは、法令に基づく場合を除き、お客様の同意なく個人情報を第三者に提供することはありません。
+            </p>
+            <ul className="list-disc list-inside ml-4 space-y-1 text-gray-700 mt-2">
+              <li>外部業務委託に伴う提供</li>
+              <li>事業譲渡・合併等に伴う提供</li>
+              <li>共同利用の場合（別途公表）</li>
+              <li>その他、法令により提供が認められる場合</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-orange-500 mb-3">アフィリエイト広告について</h2>
+            <p>
+              当サービスでは、第三者が提供する成果報酬型広告（アフィリエイトプログラム）を利用する場合があります。
+            </p>
+            <p className="mt-3">
+              これらの広告リンクを経由して商品やサービスを購入または申込みされた場合、当サービスに報酬が発生することがあります。
+            </p>
+            <p className="mt-3">
+              アフィリエイトプログラムにおいては、広告効果の測定のため、第三者が Cookie（クッキー）等の技術を用いてユーザーのアクセス情報を取得する場合があります。これにより取得される情報には、氏名・住所・メールアドレスなどの個人を特定する情報は含まれません。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-orange-500 mb-3">プライバシーポリシーの変更</h2>
+            <p>
+              当サービスは、必要に応じて本ポリシーの内容を変更する場合があります。変更内容は、本サイト上での告知またはメール等でお知らせいたします。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-orange-500 mb-3">お問い合わせ</h2>
+            <p>
+              お客様の情報の開示・訂正・利用停止・削除をご希望の場合は、
+              <Link href="/contact" className="text-orange-500 underline hover:text-orange-700 transition">
+                お問い合わせフォーム
+              </Link>
+              よりご連絡ください。ご本人確認の上、法令に従い対応いたします。
+            </p>
+            <p className="mt-2 text-gray-600 text-sm">
+              ※情報開示請求に際しては、手数料（1件あたり1,000円）をいただく場合があります。
+            </p>
+          </section>
+
+          <section className="text-sm text-gray-500 mt-8">
+            <p>2025年10月26日 制定</p>
+          </section>
+        </div>
+
+        <div className="text-center mt-12">
+          <Link
+            href="/settings"
+            className="inline-block bg-orange-500 hover:bg-orange-600 text-white px-8 py-2.5 rounded-full shadow transition"
+          >
+            戻る
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -4,6 +4,7 @@ import { useState, useRef } from "react";
 import Image from "next/image";
 import { useProfile } from "@/hooks/useProfile";
 import { useFlash } from "@/contexts/FlashContext";
+import { apiFetch } from "@/lib/api";
 
 const PREFECTURES = [
   "北海道", "青森県", "岩手県", "宮城県", "秋田県", "山形県", "福島県",
@@ -24,6 +25,21 @@ export default function ProfilePage() {
   const [submitting, setSubmitting] = useState(false);
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // メールアドレス変更
+  const [emailForm, setEmailForm] = useState(false);
+  const [newEmail, setNewEmail] = useState("");
+  const [emailPassword, setEmailPassword] = useState("");
+  const [emailErrors, setEmailErrors] = useState<string[]>([]);
+  const [emailSubmitting, setEmailSubmitting] = useState(false);
+
+  // パスワード変更
+  const [passwordForm, setPasswordForm] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [passwordErrors, setPasswordErrors] = useState<string[]>([]);
+  const [passwordSubmitting, setPasswordSubmitting] = useState(false);
 
   function startEdit() {
     setNickname(user?.nickname ?? "");
@@ -49,17 +65,62 @@ export default function ProfilePage() {
   async function handleAvatarChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
-    // リアルタイムプレビュー
     const reader = new FileReader();
     reader.onload = (ev) => setAvatarPreview(ev.target?.result as string);
     reader.readAsDataURL(file);
-    // アップロード
     try {
       await uploadAvatar(file);
       flash("notice", "アバター画像を更新しました");
     } catch {
       flash("alert", "画像のアップロードに失敗しました");
       setAvatarPreview(null);
+    }
+  }
+
+  async function handleEmailChange(e: React.FormEvent) {
+    e.preventDefault();
+    setEmailErrors([]);
+    setEmailSubmitting(true);
+    try {
+      await apiFetch("/api/v1/profile/email", {
+        method: "PATCH",
+        body: JSON.stringify({ email: newEmail, current_password: emailPassword }),
+      });
+      flash("notice", "メールアドレスを更新しました");
+      setEmailForm(false);
+      setNewEmail("");
+      setEmailPassword("");
+    } catch (err: unknown) {
+      const apiErr = err as { errors?: string[]; message?: string };
+      setEmailErrors(apiErr.errors?.length ? apiErr.errors : [apiErr.message ?? "更新に失敗しました"]);
+    } finally {
+      setEmailSubmitting(false);
+    }
+  }
+
+  async function handlePasswordChange(e: React.FormEvent) {
+    e.preventDefault();
+    setPasswordErrors([]);
+    setPasswordSubmitting(true);
+    try {
+      await apiFetch("/api/v1/profile/password", {
+        method: "PATCH",
+        body: JSON.stringify({
+          current_password: currentPassword,
+          password: newPassword,
+          password_confirmation: passwordConfirmation,
+        }),
+      });
+      flash("notice", "パスワードを変更しました");
+      setPasswordForm(false);
+      setCurrentPassword("");
+      setNewPassword("");
+      setPasswordConfirmation("");
+    } catch (err: unknown) {
+      const apiErr = err as { errors?: string[]; message?: string };
+      setPasswordErrors(apiErr.errors?.length ? apiErr.errors : [apiErr.message ?? "変更に失敗しました"]);
+    } finally {
+      setPasswordSubmitting(false);
     }
   }
 
@@ -75,103 +136,228 @@ export default function ProfilePage() {
 
   return (
     <div className="min-h-screen bg-orange-50 py-10 pb-24 px-4">
-      <div className="max-w-md mx-auto bg-white rounded-2xl shadow border border-orange-100 p-8">
-        <h1 className="text-2xl font-bold text-center text-gray-800 mb-6">
-          👤 プロフィール設定
-        </h1>
+      <div className="max-w-md mx-auto space-y-4">
 
-        {/* アバター画像 */}
-        <div className="flex flex-col items-center mb-8">
-          <div className="relative w-24 h-24 rounded-full overflow-hidden bg-orange-100 border-2 border-orange-200 mb-3">
-            {avatarSrc ? (
-              <Image
-                src={avatarSrc}
-                alt="アバター"
-                fill
-                className="object-cover"
-              />
-            ) : (
-              <div className="w-full h-full flex items-center justify-center text-4xl">
-                👤
-              </div>
-            )}
-          </div>
-          <button
-            type="button"
-            onClick={() => fileInputRef.current?.click()}
-            className="text-sm text-orange-500 hover:text-orange-600 font-semibold transition"
-          >
-            画像を変更
-          </button>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/*"
-            onChange={handleAvatarChange}
-            className="hidden"
-          />
-        </div>
+        {/* プロフィールカード */}
+        <div className="bg-white rounded-2xl shadow border border-orange-100 p-8">
+          <h1 className="text-2xl font-bold text-center text-gray-800 mb-6">
+            👤 プロフィール設定
+          </h1>
 
-        {editing ? (
-          <form onSubmit={handleSave} className="space-y-5">
-            <div>
-              <label className="block text-sm font-semibold text-gray-700 mb-1">
-                ニックネーム
-              </label>
-              <input
-                type="text"
-                value={nickname}
-                onChange={(e) => setNickname(e.target.value)}
-                required
-                className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
-              />
+          {/* アバター画像 */}
+          <div className="flex flex-col items-center mb-8">
+            <div className="relative w-24 h-24 rounded-full overflow-hidden bg-orange-100 border-2 border-orange-200 mb-3">
+              {avatarSrc ? (
+                <Image src={avatarSrc} alt="アバター" fill className="object-cover" />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center text-4xl">👤</div>
+              )}
             </div>
-            <div>
-              <label className="block text-sm font-semibold text-gray-700 mb-1">
-                都道府県
-              </label>
-              <select
-                value={prefecture}
-                onChange={(e) => setPrefecture(e.target.value)}
-                className="w-full border border-gray-300 rounded-xl p-3 bg-white focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
-              >
-                <option value="">未設定</option>
-                {PREFECTURES.map((p) => (
-                  <option key={p} value={p}>{p}</option>
-                ))}
-              </select>
-            </div>
-            <div className="flex gap-3">
-              <button
-                type="submit"
-                disabled={submitting}
-                className="flex-1 bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white font-bold py-2.5 rounded-full shadow-md transition"
-              >
-                保存
-              </button>
-              <button
-                type="button"
-                onClick={() => setEditing(false)}
-                className="flex-1 bg-gray-100 hover:bg-gray-200 text-gray-600 font-semibold py-2.5 rounded-full transition"
-              >
-                キャンセル
-              </button>
-            </div>
-          </form>
-        ) : (
-          <div className="space-y-5">
-            <Row label="ニックネーム" value={user?.nickname ?? "未設定"} />
-            <Row label="メールアドレス" value={user?.email ?? ""} />
-            <Row label="都道府県" value={user?.prefecture ?? "未設定"} />
             <button
               type="button"
-              onClick={startEdit}
-              className="w-full mt-4 bg-orange-500 hover:bg-orange-600 text-white font-bold py-2.5 rounded-full shadow-md transition"
+              onClick={() => fileInputRef.current?.click()}
+              className="text-sm text-orange-500 hover:text-orange-600 font-semibold transition"
             >
-              編集する
+              画像を変更
             </button>
+            <input ref={fileInputRef} type="file" accept="image/*" onChange={handleAvatarChange} className="hidden" />
           </div>
-        )}
+
+          {editing ? (
+            <form onSubmit={handleSave} className="space-y-5">
+              <div>
+                <label className="block text-sm font-semibold text-gray-700 mb-1">ニックネーム</label>
+                <input
+                  type="text"
+                  value={nickname}
+                  onChange={(e) => setNickname(e.target.value)}
+                  required
+                  className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-semibold text-gray-700 mb-1">都道府県</label>
+                <select
+                  value={prefecture}
+                  onChange={(e) => setPrefecture(e.target.value)}
+                  className="w-full border border-gray-300 rounded-xl p-3 bg-white focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
+                >
+                  <option value="">未設定</option>
+                  {PREFECTURES.map((p) => (
+                    <option key={p} value={p}>{p}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex gap-3">
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="flex-1 bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white font-bold py-2.5 rounded-full shadow-md transition"
+                >
+                  保存
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setEditing(false)}
+                  className="flex-1 bg-gray-100 hover:bg-gray-200 text-gray-600 font-semibold py-2.5 rounded-full transition"
+                >
+                  キャンセル
+                </button>
+              </div>
+            </form>
+          ) : (
+            <div className="space-y-5">
+              <Row label="ニックネーム" value={user?.nickname ?? "未設定"} />
+              <Row label="メールアドレス" value={user?.email ?? ""} />
+              <Row label="都道府県" value={user?.prefecture ?? "未設定"} />
+              <button
+                type="button"
+                onClick={startEdit}
+                className="w-full mt-4 bg-orange-500 hover:bg-orange-600 text-white font-bold py-2.5 rounded-full shadow-md transition"
+              >
+                編集する
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* メールアドレス変更 */}
+        <div className="bg-white rounded-2xl shadow border border-orange-100 p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-base font-bold text-gray-800">メールアドレス変更</h2>
+            {!emailForm && (
+              <button
+                type="button"
+                onClick={() => setEmailForm(true)}
+                className="text-sm text-orange-500 hover:underline font-semibold"
+              >
+                変更する
+              </button>
+            )}
+          </div>
+          {emailForm && (
+            <form onSubmit={handleEmailChange} className="space-y-4">
+              {emailErrors.length > 0 && (
+                <ul className="text-sm text-red-600 bg-red-50 border-l-4 border-red-400 rounded-xl px-3 py-2 space-y-1">
+                  {emailErrors.map((e, i) => <li key={i}>{e}</li>)}
+                </ul>
+              )}
+              <div>
+                <label className="block text-sm font-semibold text-gray-700 mb-1">新しいメールアドレス</label>
+                <input
+                  type="email"
+                  value={newEmail}
+                  onChange={(e) => setNewEmail(e.target.value)}
+                  required
+                  className="w-full border border-gray-300 rounded-xl px-3 py-2 focus:ring-2 focus:ring-orange-400 outline-none"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-semibold text-gray-700 mb-1">現在のパスワード</label>
+                <input
+                  type="password"
+                  value={emailPassword}
+                  onChange={(e) => setEmailPassword(e.target.value)}
+                  required
+                  autoComplete="current-password"
+                  className="w-full border border-gray-300 rounded-xl px-3 py-2 focus:ring-2 focus:ring-orange-400 outline-none"
+                />
+              </div>
+              <div className="flex gap-3">
+                <button
+                  type="submit"
+                  disabled={emailSubmitting}
+                  className="flex-1 bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white font-bold py-2 rounded-full shadow-md transition"
+                >
+                  {emailSubmitting ? "更新中..." : "更新する"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setEmailForm(false); setEmailErrors([]); }}
+                  className="flex-1 bg-gray-100 hover:bg-gray-200 text-gray-600 font-semibold py-2 rounded-full transition"
+                >
+                  キャンセル
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+
+        {/* パスワード変更 */}
+        <div className="bg-white rounded-2xl shadow border border-orange-100 p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-base font-bold text-gray-800">パスワード変更</h2>
+            {!passwordForm && (
+              <button
+                type="button"
+                onClick={() => setPasswordForm(true)}
+                className="text-sm text-orange-500 hover:underline font-semibold"
+              >
+                変更する
+              </button>
+            )}
+          </div>
+          {passwordForm && (
+            <form onSubmit={handlePasswordChange} className="space-y-4">
+              {passwordErrors.length > 0 && (
+                <ul className="text-sm text-red-600 bg-red-50 border-l-4 border-red-400 rounded-xl px-3 py-2 space-y-1">
+                  {passwordErrors.map((e, i) => <li key={i}>{e}</li>)}
+                </ul>
+              )}
+              <div>
+                <label className="block text-sm font-semibold text-gray-700 mb-1">現在のパスワード</label>
+                <input
+                  type="password"
+                  value={currentPassword}
+                  onChange={(e) => setCurrentPassword(e.target.value)}
+                  required
+                  autoComplete="current-password"
+                  className="w-full border border-gray-300 rounded-xl px-3 py-2 focus:ring-2 focus:ring-orange-400 outline-none"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-semibold text-gray-700 mb-1">新しいパスワード</label>
+                <input
+                  type="password"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  required
+                  autoComplete="new-password"
+                  placeholder="8文字以上"
+                  className="w-full border border-gray-300 rounded-xl px-3 py-2 focus:ring-2 focus:ring-orange-400 outline-none"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-semibold text-gray-700 mb-1">新しいパスワード（確認）</label>
+                <input
+                  type="password"
+                  value={passwordConfirmation}
+                  onChange={(e) => setPasswordConfirmation(e.target.value)}
+                  required
+                  autoComplete="new-password"
+                  className="w-full border border-gray-300 rounded-xl px-3 py-2 focus:ring-2 focus:ring-orange-400 outline-none"
+                />
+              </div>
+              <div className="flex gap-3">
+                <button
+                  type="submit"
+                  disabled={passwordSubmitting}
+                  className="flex-1 bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white font-bold py-2 rounded-full shadow-md transition"
+                >
+                  {passwordSubmitting ? "変更中..." : "変更する"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setPasswordForm(false); setPasswordErrors([]); }}
+                  className="flex-1 bg-gray-100 hover:bg-gray-200 text-gray-600 font-semibold py-2 rounded-full transition"
+                >
+                  キャンセル
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+
       </div>
     </div>
   );

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -8,8 +8,6 @@ import { useAuth } from "@/hooks/useAuth";
 import { useFlash } from "@/contexts/FlashContext";
 import { apiFetch } from "@/lib/api";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
-
 type NavItem = {
   href: string;
   label: string;
@@ -22,10 +20,10 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/family", label: "👨‍👩‍👧 ファミリー設定" },
 ];
 
-const EXTERNAL_ITEMS = [
-  { href: `${API_BASE}/terms`, label: "利用規約" },
-  { href: `${API_BASE}/privacy`, label: "プライバシーポリシー" },
-  { href: `${API_BASE}/contact`, label: "お問い合わせ" },
+const INFO_ITEMS: NavItem[] = [
+  { href: "/terms", label: "利用規約" },
+  { href: "/privacy", label: "プライバシーポリシー" },
+  { href: "/contact", label: "お問い合わせ" },
 ];
 
 export default function SettingsPage() {
@@ -100,19 +98,17 @@ export default function SettingsPage() {
           ))}
         </div>
 
-        {/* 外部リンク */}
-        <div className="bg-white rounded-2xl shadow border border-orange-100 overflow-hidden mb-6">
-          {EXTERNAL_ITEMS.map((item) => (
-            <a
+        {/* 利用規約・プライバシー・お問い合わせ */}
+        <div className="bg-white rounded-2xl shadow border border-orange-100 overflow-hidden mb-4">
+          {INFO_ITEMS.map((item) => (
+            <Link
               key={item.href}
               href={item.href}
-              target="_blank"
-              rel="noopener noreferrer"
               className="flex justify-between items-center px-5 py-4 border-b border-gray-100 last:border-none hover:bg-orange-50 transition"
             >
               <span className="text-gray-800">{item.label}</span>
-              <span className="text-gray-400">↗</span>
-            </a>
+              <span className="text-gray-400">›</span>
+            </Link>
           ))}
         </div>
 
@@ -121,10 +117,18 @@ export default function SettingsPage() {
           type="button"
           onClick={handleLogout}
           disabled={loggingOut}
-          className="block w-full text-center text-red-500 hover:text-red-600 disabled:opacity-50 font-semibold py-3 rounded-2xl border border-red-200 hover:bg-red-50 transition"
+          className="block w-full text-center text-red-500 hover:text-red-600 disabled:opacity-50 font-semibold py-3 rounded-2xl border border-red-200 hover:bg-red-50 transition mb-3"
         >
           {loggingOut ? "ログアウト中..." : "ログアウト"}
         </button>
+
+        {/* アカウント削除 */}
+        <Link
+          href="/account/delete"
+          className="block w-full text-center text-gray-400 hover:text-gray-500 text-sm py-2 transition"
+        >
+          アカウントを削除する
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/app/terms/page.tsx
+++ b/frontend/src/app/terms/page.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import Link from "next/link";
+
+/** 利用規約ページ（認証不要） */
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-[#FFF9F3] py-10 px-4 flex justify-center">
+      <div className="w-full max-w-3xl bg-white rounded-2xl shadow-lg border border-orange-100 p-8 md:p-12">
+        <h1 className="text-2xl md:text-3xl font-bold text-center text-orange-500 mb-10">
+          利用規約
+        </h1>
+
+        <div className="space-y-10 leading-relaxed text-base text-gray-800">
+          <section>
+            <p>
+              この利用規約（以下、「本規約」といいます。）は、本サービス（本サイトを含むものとし、以下、特に両者を区別しません。）の利用条件を定めるものです。本規約は、本サービスを利用するすべてのユーザーに適用されます。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-orange-500 mb-3">本規約への同意</h2>
+            <p>
+              ユーザーは、本サービスを利用することによって、本規約に有効かつ取り消し不能な同意をしたものとみなされます。本規約に同意しないユーザーは、本サービスをご利用いただけません。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-orange-500 mb-3">利用登録</h2>
+            <p>
+              本サービスの利用を希望する方は、本規約に同意の上、当社の定める方法によって利用登録を申請し、当社がこれを承認することによって、本サービスの利用登録をすることができます。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-orange-500 mb-3">登録拒否</h2>
+            <p>
+              当社は、以下のいずれかの事由があると判断した場合、利用登録の申請を承認しないことがあります。当社は登録拒否の理由について一切の開示義務を負いません。
+            </p>
+            <ul className="list-disc list-inside ml-4 space-y-1 text-gray-700 mt-2">
+              <li>虚偽の事項を届け出た場合</li>
+              <li>本規約に違反したことがある者からの申請である場合</li>
+              <li>その他、当社が利用登録を相当でないと判断した場合</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-orange-500 mb-3">未成年による利用</h2>
+            <p>
+              ユーザーが未成年である場合には、法定代理人の同意を得た上で、本サービスを利用してください。法定代理人の同意を得ずに本サービスのご利用を開始したユーザーが成年に達した場合、未成年者であった間の利用行為を追認したものとみなします。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-orange-500 mb-3">ログイン情報の管理</h2>
+            <p>
+              ユーザーは、自己の責任においてログイン情報を適切に管理するものとします。第三者による不正使用によって生じた損害について、当社は一切の責任を負いません。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-orange-500 mb-3">コンテンツのご利用</h2>
+            <p>
+              本サービスが提供する文章、画像、動画、プログラム等のコンテンツは、私的利用の範囲内でのみ利用できます。この範囲を超えた利用は禁止します。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-orange-500 mb-3">禁止事項</h2>
+            <p>ユーザーは以下の行為をしてはなりません。</p>
+            <ul className="list-disc list-inside ml-4 space-y-1 text-gray-700 mt-2">
+              <li>法令・公序良俗に違反する行為</li>
+              <li>第三者の権利・利益を侵害する行為</li>
+              <li>当社の運営を妨害する行為</li>
+              <li>不正アクセス・情報改ざん行為</li>
+              <li>他のユーザーへの迷惑行為</li>
+              <li>その他、当社が不適切と判断する行為</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-orange-500 mb-3">利用制限・停止</h2>
+            <p>
+              当社は、ユーザーが本規約に違反した場合、通知なしで本サービスの利用を制限または停止することができます。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-orange-500 mb-3">免責事項</h2>
+            <p>
+              当社は、本サービスに関してユーザーに生じたあらゆる損害について、一切の責任を負いません。ただし、消費者契約法に定める場合を除きます。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-orange-500 mb-3">準拠法・裁判管轄</h2>
+            <p>
+              本規約は日本法に準拠し、本サービスに関する紛争は当社の本店所在地を管轄する地方裁判所を専属的合意管轄とします。
+            </p>
+          </section>
+
+          <section className="text-sm text-gray-500 mt-8">
+            <p>2025年10月25日 制定</p>
+            <p>2025年10月26日 改定</p>
+          </section>
+        </div>
+
+        <div className="text-center mt-12">
+          <Link
+            href="/settings"
+            className="inline-block bg-orange-500 hover:bg-orange-600 text-white px-8 py-2.5 rounded-full shadow transition"
+          >
+            戻る
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -5,7 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
 
 /** 認証不要のパス一覧 */
-const PUBLIC_PATHS = ["/", "/login", "/guide", "/signup", "/forgot-password", "/reset-password"];
+const PUBLIC_PATHS = ["/", "/login", "/guide", "/signup", "/forgot-password", "/reset-password", "/contact", "/terms", "/privacy"];
 
 /** 認証状態を監視し、未認証時はログイン画面へリダイレクトする共通プロバイダー */
 export function AuthProvider({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary

- `/lists` ページ（カテゴリー・お店へのナビゲーション）を Next.js に実装
- `/account/delete` ページ + `DELETE /api/v1/account` でアカウント削除を実装
- プロフィールページにメール・パスワード変更フォームを追加（`PATCH /api/v1/profile/email` / `PATCH /api/v1/profile/password`）
- `/contact` / `/terms` / `/privacy` ページを Next.js に移行 + `POST /api/v1/contacts` を追加
- `/admin/settings` ページ + `GET /api/v1/admin/settings` で管理画面設定ページを実装
- 設定ページの利用規約・プライバシー・お問い合わせリンクを外部リンクから内部 Link に変更
- `AuthProvider` の `PUBLIC_PATHS` に `/contact` `/terms` `/privacy` を追加

## Test plan

- [ ] `/lists` にアクセスしてカテゴリー・お店リンクが表示されること
- [ ] `/settings` の「アカウントを削除する」→ `/account/delete` に遷移し、チェックONで削除できること
- [ ] プロフィールページでメールアドレス・パスワードを変更できること（現在のパスワード必須）
- [ ] `/contact` でお問い合わせフォームが送信できること
- [ ] `/terms` `/privacy` が認証不要で表示されること
- [ ] `/admin/settings` で家族メンバー上限が表示されること
- [ ] 設定ページのリンクが Next.js 内部ルートに遷移すること

Closes #239 #240 #241 #242 #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)