### PR TITLE
不足していたテストを追加する

### DIFF
--- a/frontend/tests/hooks/useProducts.test.ts
+++ b/frontend/tests/hooks/useProducts.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useProducts } from "@/hooks/useProducts";
+
+vi.mock("swr");
+vi.mock("@/lib/api");
+
+const mockProduct = {
+  id: 1,
+  public_id: "abc123",
+  name: "牛乳",
+  category_id: null,
+  category_name: null,
+  default_unit: null,
+  image_url: null,
+};
+
+const mockResponse = {
+  data: [ mockProduct ],
+  meta: { total: 1, current_page: 1, total_pages: 1 },
+};
+
+describe("useProducts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("商品一覧を返す", async () => {
+    const useSWR = (await import("swr")).default;
+    vi.mocked(useSWR).mockReturnValue({
+      data: mockResponse,
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as ReturnType<typeof useSWR>);
+
+    const { result } = renderHook(() => useProducts());
+
+    await waitFor(() => {
+      expect(result.current.products).toEqual([ mockProduct ]);
+    });
+  });
+
+  it("metaを返す", async () => {
+    const useSWR = (await import("swr")).default;
+    vi.mocked(useSWR).mockReturnValue({
+      data: mockResponse,
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as ReturnType<typeof useSWR>);
+
+    const { result } = renderHook(() => useProducts());
+
+    await waitFor(() => {
+      expect(result.current.meta?.total).toBe(1);
+    });
+  });
+
+  it("データがない場合は空配列を返す", async () => {
+    const useSWR = (await import("swr")).default;
+    vi.mocked(useSWR).mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as ReturnType<typeof useSWR>);
+
+    const { result } = renderHook(() => useProducts());
+    expect(result.current.products).toEqual([]);
+  });
+
+  it("データ取得中はisLoadingがtrueになる", async () => {
+    const useSWR = (await import("swr")).default;
+    vi.mocked(useSWR).mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: true,
+      mutate: vi.fn(),
+    } as ReturnType<typeof useSWR>);
+
+    const { result } = renderHook(() => useProducts());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("ページパラメータがURLに含まれる", async () => {
+    const useSWR = (await import("swr")).default;
+    vi.mocked(useSWR).mockReturnValue({
+      data: mockResponse,
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as ReturnType<typeof useSWR>);
+
+    renderHook(() => useProducts(2));
+
+    const swrKey = vi.mocked(useSWR).mock.calls[0][0] as string;
+    expect(swrKey).toContain("page=2");
+  });
+
+  it("検索パラメータがURLに含まれる", async () => {
+    const useSWR = (await import("swr")).default;
+    vi.mocked(useSWR).mockReturnValue({
+      data: mockResponse,
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as ReturnType<typeof useSWR>);
+
+    renderHook(() => useProducts(1, { name_cont: "牛乳" }));
+
+    const swrKey = vi.mocked(useSWR).mock.calls[0][0] as string;
+    expect(swrKey).toContain("name_cont");
+  });
+});

--- a/frontend/tests/hooks/useShops.test.ts
+++ b/frontend/tests/hooks/useShops.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useShops } from "@/hooks/useShops";
+
+vi.mock("swr");
+vi.mock("@/lib/api");
+
+const mockShops = [
+  { id: 1, name: "スーパーA", memo: null },
+  { id: 2, name: "スーパーB", memo: "安い" },
+];
+
+describe("useShops", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("店舗一覧を返す", async () => {
+    const useSWR = (await import("swr")).default;
+    vi.mocked(useSWR).mockReturnValue({
+      data: mockShops,
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as ReturnType<typeof useSWR>);
+
+    const { result } = renderHook(() => useShops());
+
+    await waitFor(() => {
+      expect(result.current.shops).toEqual(mockShops);
+    });
+  });
+
+  it("データ取得中はisLoadingがtrueになる", async () => {
+    const useSWR = (await import("swr")).default;
+    vi.mocked(useSWR).mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: true,
+      mutate: vi.fn(),
+    } as ReturnType<typeof useSWR>);
+
+    const { result } = renderHook(() => useShops());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("データがない場合は空配列を返す", async () => {
+    const useSWR = (await import("swr")).default;
+    vi.mocked(useSWR).mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as ReturnType<typeof useSWR>);
+
+    const { result } = renderHook(() => useShops());
+    expect(result.current.shops).toEqual([]);
+  });
+
+  it("createShop を呼ぶと POST が実行される", async () => {
+    const useSWR = (await import("swr")).default;
+    const mutate = vi.fn();
+    vi.mocked(useSWR).mockReturnValue({
+      data: mockShops,
+      error: undefined,
+      isLoading: false,
+      mutate,
+    } as ReturnType<typeof useSWR>);
+
+    const { apiFetch } = await import("@/lib/api");
+    vi.mocked(apiFetch).mockResolvedValue({ id: 3, name: "スーパーC", memo: null });
+
+    const { result } = renderHook(() => useShops());
+
+    await act(async () => {
+      await result.current.createShop({ name: "スーパーC", memo: null });
+    });
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/shops", {
+      method: "POST",
+      body: JSON.stringify({ shop: { name: "スーパーC", memo: null } }),
+    });
+    expect(mutate).toHaveBeenCalled();
+  });
+
+  it("updateShop を呼ぶと PATCH が実行される", async () => {
+    const useSWR = (await import("swr")).default;
+    const mutate = vi.fn();
+    vi.mocked(useSWR).mockReturnValue({
+      data: mockShops,
+      error: undefined,
+      isLoading: false,
+      mutate,
+    } as ReturnType<typeof useSWR>);
+
+    const { apiFetch } = await import("@/lib/api");
+    vi.mocked(apiFetch).mockResolvedValue({ id: 1, name: "更新済み", memo: null });
+
+    const { result } = renderHook(() => useShops());
+
+    await act(async () => {
+      await result.current.updateShop(1, { name: "更新済み", memo: null });
+    });
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/shops/1", {
+      method: "PATCH",
+      body: JSON.stringify({ shop: { name: "更新済み", memo: null } }),
+    });
+    expect(mutate).toHaveBeenCalled();
+  });
+
+  it("deleteShop を呼ぶと DELETE が実行される", async () => {
+    const useSWR = (await import("swr")).default;
+    const mutate = vi.fn();
+    vi.mocked(useSWR).mockReturnValue({
+      data: mockShops,
+      error: undefined,
+      isLoading: false,
+      mutate,
+    } as ReturnType<typeof useSWR>);
+
+    const { apiFetch } = await import("@/lib/api");
+    vi.mocked(apiFetch).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useShops());
+
+    await act(async () => {
+      await result.current.deleteShop(1);
+    });
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/shops/1", { method: "DELETE" });
+    expect(mutate).toHaveBeenCalled();
+  });
+});

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe Contact, type: :model do
+  describe "バリデーション" do
+    it "有効なファクトリを持つこと" do
+      expect(build(:contact)).to be_valid
+    end
+
+    it "nicknameが空では無効であること" do
+      contact = build(:contact, nickname: nil)
+      expect(contact).not_to be_valid
+      expect(contact.errors[:nickname]).to be_present
+    end
+
+    it "emailが空では無効であること" do
+      contact = build(:contact, email: nil)
+      expect(contact).not_to be_valid
+      expect(contact.errors[:email]).to be_present
+    end
+
+    it "bodyが空では無効であること" do
+      contact = build(:contact, body: nil)
+      expect(contact).not_to be_valid
+      expect(contact.errors[:body]).to be_present
+    end
+  end
+
+  describe "enum status" do
+    it "デフォルトのstatusはunread" do
+      contact = build(:contact)
+      expect(contact.status).to eq("unread")
+    end
+
+    it "pending に変更できる" do
+      contact = create(:contact)
+      contact.pending!
+      expect(contact.reload.status).to eq("pending")
+    end
+
+    it "resolved に変更できる" do
+      contact = create(:contact)
+      contact.resolved!
+      expect(contact.reload.status).to eq("resolved")
+    end
+  end
+
+  describe ".ransackable_attributes" do
+    it "検索可能な属性を返す" do
+      attrs = Contact.ransackable_attributes
+      expect(attrs).to include("nickname", "email", "body", "status", "created_at")
+    end
+  end
+end

--- a/spec/models/family_spec.rb
+++ b/spec/models/family_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe Family, type: :model do
+  let(:owner) { create(:user, :without_callbacks) }
+  let(:family) { create(:family, owner: owner) }
+
+  describe "バリデーション" do
+    it "有効なファクトリを持つこと" do
+      expect(family).to be_valid
+    end
+
+    it "名前が未設定の場合はデフォルト名が設定される" do
+      f = create(:family, name: nil, owner: owner)
+      expect(f.name).to eq("ファミリー")
+    end
+
+    it "invite_tokenが自動生成される" do
+      f = build(:family, invite_token: nil, owner: owner)
+      f.valid?
+      expect(f.invite_token).to be_present
+    end
+  end
+
+  describe "アソシエーション" do
+    it "作成時にファミリーショッピングリストが自動作成される" do
+      expect { create(:family, owner: owner) }.to change(ShoppingList, :count).by(1)
+    end
+  end
+
+  describe "#full?" do
+    it "メンバーが上限（3人）の場合trueを返す" do
+      family.users << owner
+      2.times { family.users << create(:user, :without_callbacks) }
+      expect(family.full?).to be true
+    end
+
+    it "メンバーが上限未満の場合falseを返す" do
+      family.users << owner
+      expect(family.full?).to be false
+    end
+  end
+
+  describe "#remaining_slots" do
+    it "残り枠数を返す" do
+      family.users << owner
+      expect(family.remaining_slots).to eq(Family::MAX_MEMBERS - 1)
+    end
+
+    it "メンバーが上限に達している場合は0を返す" do
+      family.users << owner
+      2.times { family.users << create(:user, :without_callbacks) }
+      expect(family.remaining_slots).to eq(0)
+    end
+  end
+
+  describe "#regenerate_invite_token!" do
+    it "invite_tokenが更新される" do
+      old_token = family.invite_token
+      family.regenerate_invite_token!
+      expect(family.reload.invite_token).not_to eq(old_token)
+    end
+  end
+end

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe ShoppingList, type: :model do
+  describe "バリデーション" do
+    it "有効なファクトリを持つこと" do
+      expect(build(:shopping_list)).to be_valid
+    end
+
+    it "nameが空では無効であること" do
+      list = build(:shopping_list, name: nil)
+      expect(list).not_to be_valid
+      expect(list.errors[:name]).to be_present
+    end
+  end
+
+  describe "アソシエーション" do
+    it "shopping_itemsを持てる" do
+      list = create(:shopping_list)
+      item = create(:shopping_item, shopping_list: list)
+      expect(list.shopping_items).to include(item)
+    end
+
+    it "shopping_list削除時にshopping_itemsも削除される" do
+      list = create(:shopping_list)
+      create(:shopping_item, shopping_list: list)
+      expect { list.destroy }.to change(ShoppingItem, :count).by(-1)
+    end
+  end
+
+  describe "#to_param" do
+    it "public_idを返す" do
+      list = create(:shopping_list)
+      expect(list.to_param).to eq(list.public_id)
+    end
+  end
+end

--- a/spec/requests/api/v1/account_spec.rb
+++ b/spec/requests/api/v1/account_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Account", type: :request do
+  describe "DELETE /api/v1/account" do
+    let(:user) { create(:user, :without_callbacks) }
+
+    context "認証済みの場合" do
+      before { sign_in(user, scope: :user) }
+
+      it "200を返す" do
+        delete "/api/v1/account"
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "メッセージを返す" do
+        delete "/api/v1/account"
+        json = response.parsed_body
+        expect(json["message"]).to be_present
+      end
+
+      it "ユーザーがDBから削除される" do
+        expect { delete "/api/v1/account" }.to change(User, :count).by(-1)
+      end
+
+      it "削除後は同じユーザーでAPIにアクセスできない" do
+        delete "/api/v1/account"
+        get "/api/v1/me"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "未認証の場合" do
+      it "401を返す" do
+        delete "/api/v1/account"
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "ユーザーが削除されない" do
+        user
+        expect { delete "/api/v1/account" }.not_to change(User, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/admin/abnormal_prices_spec.rb
+++ b/spec/requests/api/v1/admin/abnormal_prices_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Admin::AbnormalPrices", type: :request do
+  let(:admin) { create(:user, :without_callbacks, :admin) }
+  let(:general_user) { create(:user, :without_callbacks) }
+
+  describe "GET /api/v1/admin/abnormal_prices" do
+    context "管理者の場合" do
+      before { sign_in(admin, scope: :user) }
+
+      it "200を返す" do
+        get "/api/v1/admin/abnormal_prices"
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "配列を返す" do
+        get "/api/v1/admin/abnormal_prices"
+        json = response.parsed_body
+        expect(json).to be_an(Array)
+      end
+
+      context "異常価格レコードが存在する場合" do
+        let(:user) { create(:user, :without_callbacks) }
+        let(:product) { create(:product, user: user) }
+        let(:shop) { create(:shop, user: user) }
+
+        before do
+          # 平均より大幅に高い価格レコードを作成して異常値を発生させる
+          create(:price_record, product: product, shop: shop, user: user, price: 100)
+          create(:price_record, product: product, shop: shop, user: user, price: 110)
+          create(:price_record, product: product, shop: shop, user: user, price: 10_000)
+        end
+
+        it "異常価格レコードに必要なフィールドを含む" do
+          get "/api/v1/admin/abnormal_prices"
+          json = response.parsed_body
+          # 異常価格が検出された場合のフィールド確認
+          if json.any?
+            record = json.first
+            expect(record).to have_key("id")
+            expect(record).to have_key("price")
+            expect(record).to have_key("product_name")
+            expect(record).to have_key("shop_name")
+          end
+        end
+      end
+    end
+
+    context "一般ユーザーの場合" do
+      before { sign_in(general_user, scope: :user) }
+
+      it "403を返す" do
+        get "/api/v1/admin/abnormal_prices"
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "未認証の場合" do
+      it "401を返す" do
+        get "/api/v1/admin/abnormal_prices"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/admin/settings_spec.rb
+++ b/spec/requests/api/v1/admin/settings_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Admin::Settings", type: :request do
+  let(:admin) { create(:user, :without_callbacks, :admin) }
+  let(:general_user) { create(:user, :without_callbacks) }
+
+  describe "GET /api/v1/admin/settings" do
+    context "管理者の場合" do
+      before { sign_in(admin, scope: :user) }
+
+      it "200を返す" do
+        get "/api/v1/admin/settings"
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "max_family_membersを返す" do
+        get "/api/v1/admin/settings"
+        json = response.parsed_body
+        expect(json["max_family_members"]).to eq(Family::MAX_MEMBERS)
+      end
+    end
+
+    context "一般ユーザーの場合" do
+      before { sign_in(general_user, scope: :user) }
+
+      it "403を返す" do
+        get "/api/v1/admin/settings"
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "未認証の場合" do
+      it "401を返す" do
+        get "/api/v1/admin/settings"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/contacts_spec.rb
+++ b/spec/requests/api/v1/contacts_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Contacts", type: :request do
+  describe "POST /api/v1/contacts" do
+    let(:valid_params) do
+      {
+        nickname: "テスト太郎",
+        email: "test@example.com",
+        message: "テストのお問い合わせ内容です"
+      }
+    end
+
+    context "正常な入力の場合" do
+      before do
+        allow(ContactMailer).to receive_message_chain(:contact_email, :deliver_now)
+        allow(ContactMailer).to receive_message_chain(:auto_reply, :deliver_now)
+      end
+
+      it "201を返す" do
+        post "/api/v1/contacts", params: valid_params
+        expect(response).to have_http_status(:created)
+      end
+
+      it "メッセージを返す" do
+        post "/api/v1/contacts", params: valid_params
+        json = response.parsed_body
+        expect(json["message"]).to be_present
+      end
+
+      it "お問い合わせがDBに保存される" do
+        expect {
+          post "/api/v1/contacts", params: valid_params
+        }.to change(Contact, :count).by(1)
+      end
+
+      it "管理者宛メールと自動返信メールが送信される" do
+        mailer_double = double("mailer", deliver_now: true)
+        allow(ContactMailer).to receive(:contact_email).and_return(mailer_double)
+        allow(ContactMailer).to receive(:auto_reply).and_return(mailer_double)
+
+        post "/api/v1/contacts", params: valid_params
+
+        expect(ContactMailer).to have_received(:contact_email)
+        expect(ContactMailer).to have_received(:auto_reply)
+      end
+    end
+
+    context "必須項目が空の場合" do
+      before do
+        allow(ContactMailer).to receive_message_chain(:contact_email, :deliver_now)
+        allow(ContactMailer).to receive_message_chain(:auto_reply, :deliver_now)
+      end
+
+      it "nicknameが空の場合は422を返す" do
+        post "/api/v1/contacts", params: valid_params.merge(nickname: "")
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "emailが空の場合は422を返す" do
+        post "/api/v1/contacts", params: valid_params.merge(email: "")
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "messageが空の場合は422を返す" do
+        post "/api/v1/contacts", params: valid_params.merge(message: "")
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "422の場合はerrorsキーを含む" do
+        post "/api/v1/contacts", params: valid_params.merge(nickname: "")
+        json = response.parsed_body
+        expect(json["errors"]).to be_present
+      end
+    end
+
+    context "未認証でもアクセスできること" do
+      before do
+        allow(ContactMailer).to receive_message_chain(:contact_email, :deliver_now)
+        allow(ContactMailer).to receive_message_chain(:auto_reply, :deliver_now)
+      end
+
+      it "認証なしで201を返す" do
+        post "/api/v1/contacts", params: valid_params
+        expect(response).to have_http_status(:created)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/passwords_spec.rb
+++ b/spec/requests/api/v1/passwords_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Passwords", type: :request do
+  describe "POST /api/v1/passwords（パスワードリセットメール送信）" do
+    let!(:user) { create(:user, :without_callbacks, email: "user@example.com") }
+
+    context "登録済みのメールアドレスの場合" do
+      it "200を返す" do
+        post "/api/v1/passwords", params: { email: "user@example.com" }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "メッセージを返す" do
+        post "/api/v1/passwords", params: { email: "user@example.com" }
+        json = response.parsed_body
+        expect(json["message"]).to be_present
+      end
+    end
+
+    context "未登録のメールアドレスの場合" do
+      it "200を返す（メール存在確認攻撃を防ぐため）" do
+        post "/api/v1/passwords", params: { email: "notfound@example.com" }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "登録済みと同じメッセージを返す" do
+        post "/api/v1/passwords", params: { email: "notfound@example.com" }
+        json = response.parsed_body
+        expect(json["message"]).to be_present
+      end
+    end
+
+    context "未認証でもアクセスできること" do
+      it "認証なしで200を返す" do
+        post "/api/v1/passwords", params: { email: "user@example.com" }
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "PATCH /api/v1/passwords（パスワードリセット）" do
+    let!(:user) { create(:user, :without_callbacks) }
+
+    context "有効なリセットトークンの場合" do
+      let(:token) do
+        user.send_reset_password_instructions
+        user.reset_password_token
+      end
+
+      it "200を返す" do
+        raw_token = user.send(:set_reset_password_token)
+        patch "/api/v1/passwords", params: {
+          reset_password_token: raw_token,
+          password: "newpassword123",
+          password_confirmation: "newpassword123"
+        }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "メッセージを返す" do
+        raw_token = user.send(:set_reset_password_token)
+        patch "/api/v1/passwords", params: {
+          reset_password_token: raw_token,
+          password: "newpassword123",
+          password_confirmation: "newpassword123"
+        }
+        json = response.parsed_body
+        expect(json["message"]).to be_present
+      end
+    end
+
+    context "無効なリセットトークンの場合" do
+      it "422を返す" do
+        patch "/api/v1/passwords", params: {
+          reset_password_token: "invalid_token",
+          password: "newpassword123",
+          password_confirmation: "newpassword123"
+        }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "パスワードが不一致の場合" do
+      it "422を返す" do
+        raw_token = user.send(:set_reset_password_token)
+        patch "/api/v1/passwords", params: {
+          reset_password_token: raw_token,
+          password: "newpassword123",
+          password_confirmation: "different"
+        }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/profile_spec.rb
+++ b/spec/requests/api/v1/profile_spec.rb
@@ -27,6 +27,92 @@ RSpec.describe "Api::V1::Profile", type: :request do
     end
   end
 
+  describe "PATCH /api/v1/profile/email" do
+    it "200とメッセージを返す" do
+      patch "/api/v1/profile/email", params: {
+        email: "new@example.com",
+        current_password: "password"
+      }
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json["message"]).to be_present
+    end
+
+    it "メールアドレスがDBに反映される" do
+      patch "/api/v1/profile/email", params: {
+        email: "updated@example.com",
+        current_password: "password"
+      }
+      expect(user.reload.email).to eq("updated@example.com")
+    end
+
+    it "現在のパスワードが誤りの場合は422を返す" do
+      patch "/api/v1/profile/email", params: {
+        email: "new@example.com",
+        current_password: "wrongpassword"
+      }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    context "未認証の場合" do
+      before { sign_out :user }
+      it "401を返す" do
+        patch "/api/v1/profile/email", params: { email: "x@example.com", current_password: "p" }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "PATCH /api/v1/profile/password" do
+    it "200とメッセージを返す" do
+      patch "/api/v1/profile/password", params: {
+        current_password: "password",
+        password: "newpassword123",
+        password_confirmation: "newpassword123"
+      }
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json["message"]).to be_present
+    end
+
+    it "パスワードがDBに反映される" do
+      patch "/api/v1/profile/password", params: {
+        current_password: "password",
+        password: "newpassword123",
+        password_confirmation: "newpassword123"
+      }
+      expect(user.reload.valid_password?("newpassword123")).to be true
+    end
+
+    it "現在のパスワードが誤りの場合は422を返す" do
+      patch "/api/v1/profile/password", params: {
+        current_password: "wrongpassword",
+        password: "newpassword123",
+        password_confirmation: "newpassword123"
+      }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "パスワードが不一致の場合は422を返す" do
+      patch "/api/v1/profile/password", params: {
+        current_password: "password",
+        password: "newpassword123",
+        password_confirmation: "different"
+      }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    context "未認証の場合" do
+      before { sign_out :user }
+      it "401を返す" do
+        patch "/api/v1/profile/password", params: {
+          current_password: "p", password: "x", password_confirmation: "x"
+        }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
   context "未認証の場合" do
     before { sign_out :user }
     it "401を返す" do

--- a/spec/requests/api/v1/registrations_spec.rb
+++ b/spec/requests/api/v1/registrations_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Registrations", type: :request do
+  describe "POST /api/v1/registrations" do
+    let(:valid_params) do
+      {
+        nickname: "テストユーザー",
+        email: "new@example.com",
+        password: "password123",
+        password_confirmation: "password123"
+      }
+    end
+
+    context "正常な入力の場合" do
+      it "201を返す" do
+        post "/api/v1/registrations", params: valid_params
+        expect(response).to have_http_status(:created)
+      end
+
+      it "メッセージを返す" do
+        post "/api/v1/registrations", params: valid_params
+        json = response.parsed_body
+        expect(json["message"]).to be_present
+      end
+
+      it "ユーザーがDBに作成される" do
+        expect {
+          post "/api/v1/registrations", params: valid_params
+        }.to change(User, :count).by(1)
+      end
+    end
+
+    context "メールアドレスが空の場合" do
+      it "422を返す" do
+        post "/api/v1/registrations", params: valid_params.merge(email: "")
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "errorsキーを含むJSONを返す" do
+        post "/api/v1/registrations", params: valid_params.merge(email: "")
+        json = response.parsed_body
+        expect(json["errors"]).to be_present
+      end
+    end
+
+    context "パスワードが不一致の場合" do
+      it "422を返す" do
+        post "/api/v1/registrations", params: valid_params.merge(password_confirmation: "wrong")
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "すでに登録済みのメールアドレスの場合" do
+      before { create(:user, :without_callbacks, email: "new@example.com") }
+
+      it "422を返す" do
+        post "/api/v1/registrations", params: valid_params
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "未認証でもアクセスできること" do
+      it "認証なしで201を返す" do
+        post "/api/v1/registrations", params: valid_params
+        expect(response).to have_http_status(:created)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Rails モデルスペック**: `Family`・`Contact`・`ShoppingList` の3モデルが未テストだったため追加
- **Rails リクエストスペック**: PR #244 で追加した API エンドポイント（registrations・passwords・account・contacts・admin/settings・admin/abnormal_prices）のテストを追加。`profile_spec.rb` にメール・パスワード変更エンドポイントを追記
- **フロントエンド Vitest**: `useShops`・`useProducts` フックのテストを追加

## Test plan

- [ ] `bundle exec rspec spec/models/family_spec.rb spec/models/contact_spec.rb spec/models/shopping_list_spec.rb` が全件パスすること
- [ ] `bundle exec rspec spec/requests/api/v1/` 配下の新規スペックが全件パスすること
- [ ] `npm test tests/hooks/useShops.test.ts tests/hooks/useProducts.test.ts` が全件パスすること

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)