### PR TITLE
ログアウト後の誤リダイレクト（/login）を修正する

### DIFF
--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
 import { useFlash } from "@/contexts/FlashContext";
 import { apiFetch } from "@/lib/api";
@@ -29,15 +28,14 @@ const INFO_ITEMS: NavItem[] = [
 export default function SettingsPage() {
   const { user, isLoading } = useAuth();
   const { flash } = useFlash();
-  const router = useRouter();
   const [loggingOut, setLoggingOut] = useState(false);
 
   async function handleLogout() {
     setLoggingOut(true);
     try {
       await apiFetch("/api/v1/sessions", { method: "DELETE" });
-      flash("notice", "ログアウトしました");
-      router.replace("/");
+      // フルリロードで SWR キャッシュをクリアし AuthProvider の誤リダイレクトを防ぐ
+      window.location.href = "/";
     } catch {
       flash("alert", "ログアウトに失敗しました");
       setLoggingOut(false);


### PR DESCRIPTION
## Summary

- ログアウト後に `/` ではなく `/login` に遷移してしまうバグを修正
- **原因**: `router.replace("/")` はクライアントサイドナビゲーションのため、SWR がセッション切れの 401 を検知した `AuthProvider` が `/login` へ上書きリダイレクトしてしまっていた
- **修正**: `window.location.href = "/"` によるフルリロードに変更し、SWR キャッシュをクリアしてからタイトル画面へ遷移する

## Test plan

- [ ] ログアウトボタンを押すとタイトル画面（`/`）に遷移することを確認
- [ ] ログアウト後にコンソールに 401 エラーが出ないことを確認
- [ ] ログアウト失敗時にエラーメッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)