### PR TITLE
不要な /api/v1/me リクエストを削減する

### DIFF
--- a/frontend/src/components/layout/BottomNav.tsx
+++ b/frontend/src/components/layout/BottomNav.tsx
@@ -25,10 +25,12 @@ const HIDDEN_PATHS = ["/", "/login"];
 /** 画面下部固定のナビゲーションバー。Rails 版 shared/_footer.html.erb を再現 */
 export function BottomNav() {
   const pathname = usePathname();
-  const { user } = useAuth();
+  const isHidden = HIDDEN_PATHS.includes(pathname) || pathname.startsWith("/admin");
+  // 非表示パスでは /api/v1/me を呼ばない
+  const { user } = useAuth(!isHidden);
 
   // ランディング・ログイン・admin 配下では非表示
-  if (HIDDEN_PATHS.includes(pathname) || pathname.startsWith("/admin")) {
+  if (isHidden) {
     return null;
   }
 

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -9,8 +9,9 @@ export function useAuth(enabled = true) {
     enabled ? "/api/v1/me" : null,
     (path: string) => apiFetch<User>(path),
     {
-      // 未認証エラーはリトライしない
+      // 未認証エラーはリトライしない・フォーカス時の再検証もしない
       shouldRetryOnError: false,
+      revalidateOnFocus: false,
     }
   );
 


### PR DESCRIPTION
## Summary

- `BottomNav` が非表示パス（`/`・`/login`・`/admin` 配下）でも `useAuth()` を呼んでいたため、不要な 401 エラーが発生していた問題を修正
- SWR のフォーカス再検証（`revalidateOnFocus`）が有効なままで、ウィンドウフォーカス時に `/api/v1/me` が再リクエストされていた問題を修正

## 変更内容

- `BottomNav.tsx`: `isHidden` を事前に計算して `useAuth(!isHidden)` に変更し、非表示パスでは API を呼ばないようにする
- `useAuth.ts`: `revalidateOnFocus: false` を追加し、フォーカス時の再リクエストを抑制する

## Test plan

- [ ] ランディングページ（`/`）・ログインページ（`/login`）でコンソールに 401 エラーが出ないことを確認
- [ ] ログイン後のページ（`/home` 等）で通常通り認証チェックが動作することを確認
- [ ] ウィンドウを切り替えても `/api/v1/me` が再リクエストされないことを確認
- [ ] `npm test` が全て通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)