### PR TITLE
未実装だったフラッシュメッセージ・エラーメッセージを追加する

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-import { useState, type FormEvent } from "react";
+import { useState, type FormEvent, Suspense } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { apiFetch } from "@/lib/api";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
 
-export default function LoginPage() {
+function LoginForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const resetSuccess = searchParams.get("reset") === "success";
+
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [rememberMe, setRememberMe] = useState(false);
@@ -43,6 +46,13 @@ export default function LoginPage() {
 
         {/* メール/パスワードフォーム */}
         <form onSubmit={handleSubmit} className="space-y-4">
+          {/* パスワード変更成功メッセージ */}
+          {resetSuccess && (
+            <p className="text-sm text-green-700 bg-green-50 border-l-4 border-green-400 rounded-xl px-3 py-2">
+              パスワードを変更しました。新しいパスワードでログインしてください。
+            </p>
+          )}
+          {/* ログインエラーメッセージ */}
           {error && (
             <p className="text-sm text-red-600 bg-red-50 border-l-4 border-red-400 rounded-xl px-3 py-2">
               {error}
@@ -151,5 +161,13 @@ export default function LoginPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
   );
 }

--- a/frontend/src/app/shopping_list/page.tsx
+++ b/frontend/src/app/shopping_list/page.tsx
@@ -2,12 +2,14 @@
 
 import { useState } from "react";
 import { useShoppingList } from "@/hooks/useShoppingList";
+import { useFlash } from "@/contexts/FlashContext";
 import { ShoppingItemRow } from "@/components/shopping/ShoppingItemRow";
 import { AutocompleteInput } from "@/components/shopping/AutocompleteInput";
 
 export default function ShoppingListPage() {
   const { list, isLoading, addItem, togglePurchased, deleteItem, deletePurchased } =
     useShoppingList();
+  const { flash } = useFlash();
   const [name, setName] = useState("");
   const [memo, setMemo] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -20,8 +22,34 @@ export default function ShoppingListPage() {
       await addItem({ name: name.trim(), memo: memo.trim() || null });
       setName("");
       setMemo("");
+    } catch {
+      flash("alert", "追加に失敗しました");
     } finally {
       setSubmitting(false);
+    }
+  }
+
+  async function handleToggle(id: number, purchased: boolean) {
+    try {
+      await togglePurchased(id, purchased);
+    } catch {
+      flash("alert", "更新に失敗しました");
+    }
+  }
+
+  async function handleDelete(id: number) {
+    try {
+      await deleteItem(id);
+    } catch {
+      flash("alert", "削除に失敗しました");
+    }
+  }
+
+  async function handleDeletePurchased() {
+    try {
+      await deletePurchased();
+    } catch {
+      flash("alert", "削除に失敗しました");
     }
   }
 
@@ -82,8 +110,8 @@ export default function ShoppingListPage() {
             <ShoppingItemRow
               key={item.id}
               item={item}
-              onToggle={togglePurchased}
-              onDelete={deleteItem}
+              onToggle={handleToggle}
+              onDelete={handleDelete}
             />
           ))}
         </ul>
@@ -97,7 +125,7 @@ export default function ShoppingListPage() {
             {purchased.length > 0 && (
               <button
                 type="button"
-                onClick={deletePurchased}
+                onClick={handleDeletePurchased}
                 className="text-red-500 hover:text-red-600 text-sm font-medium transition"
               >
                 🗑 購入済みを削除
@@ -109,8 +137,8 @@ export default function ShoppingListPage() {
               <ShoppingItemRow
                 key={item.id}
                 item={item}
-                onToggle={togglePurchased}
-                onDelete={deleteItem}
+                onToggle={handleToggle}
+                onDelete={handleDelete}
               />
             ))}
           </ul>


### PR DESCRIPTION
## Summary

- `shopping_list`: アイテム追加・購入済みトグル・削除・一括削除が失敗したとき、ユーザーへのフィードバックがなかった問題を修正
- `login`: パスワードリセット完了後に `/login?reset=success` へリダイレクトしていたが、クエリパラメータを読み取っていなかったため成功メッセージが表示されていなかった問題を修正

## 変更内容

- `shopping_list/page.tsx`: `useFlash` を追加し、各操作のエラー時に `flash("alert", ...)` を呼ぶハンドラーを追加
- `login/page.tsx`: `useSearchParams` で `?reset=success` を読み取り、成功メッセージをフォーム上部にインライン表示。`Suspense` でラップ

## Test plan

- [ ] ショッピングリストでオフライン時など意図的にエラーを起こし、フラッシュアラートが表示されることを確認
- [ ] パスワードリセットメールからリセットを完了後、ログイン画面に「パスワードを変更しました」が表示されることを確認
- [ ] `npm test` が全て通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)