### PR TITLE
iOS WebView では Next.js BottomNav を非表示にする

### DIFF
--- a/frontend/src/components/layout/BottomNav.tsx
+++ b/frontend/src/components/layout/BottomNav.tsx
@@ -26,11 +26,14 @@ const HIDDEN_PATHS = ["/", "/login"];
 export function BottomNav() {
   const pathname = usePathname();
   const isHidden = HIDDEN_PATHS.includes(pathname) || pathname.startsWith("/admin");
-  // 非表示パスでは /api/v1/me を呼ばない
-  const { user } = useAuth(!isHidden);
+  // iOS WebView ではネイティブタブバーが代替するため表示しない
+  const isIOSWebView =
+    typeof navigator !== "undefined" && navigator.userAgent.includes("okaimonote-ios");
+  // 非表示パス・iOS WebView では /api/v1/me を呼ばない
+  const { user } = useAuth(!isHidden && !isIOSWebView);
 
-  // ランディング・ログイン・admin 配下では非表示
-  if (isHidden) {
+  // ランディング・ログイン・admin 配下・iOS WebView では非表示
+  if (isHidden || isIOSWebView) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

- iOS アプリ（okaimonote-ios）はネイティブの `CustomTabBar` を持つため、WebView 内に Next.js の `BottomNav` が描画されると二重フッターになる問題を修正
- User-Agent に `"okaimonote-ios"` が含まれる場合（`WebViewStore.swift` で設定）は `BottomNav` を非表示にし、`/api/v1/me` の不要な呼び出しも抑制する

## 変更内容

- `BottomNav.tsx`: `navigator.userAgent.includes("okaimonote-ios")` を検出し、iOS WebView ではコンポーネントを `null` で返す

## 関連する iOS 側の修正（別途 Xcode で対応が必要）

`okaimonote-ios/ios/App/App/AppLogic.swift` の `shouldShowFooter()` に Next.js の認証不要パスを追加する必要があります。

```swift
// 追加が必要なパス
"/login",
"/signup",
"/forgot-password",
"/reset-password",
"/guide",
"/contact",
"/terms",
"/privacy",
```

現状、`AuthProvider` がセッション切れの保護ページから `/login` にリダイレクトする際、iOS ネイティブフッターが `/login` で表示されてしまいます（`AppLogic` が旧 Rails パス `/users/sign_in` しか知らないため）。

## Test plan

- [ ] iOS WebView で `/home` を開き、Next.js BottomNav が表示されないことを確認（iOS ネイティブタブバーのみ表示）
- [ ] Web ブラウザで `/home` を開き、Next.js BottomNav が通常通り表示されることを確認
- [ ] `npm test` が全て通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)