### PR TITLE
iOS WebView の表示改善（BottomNav 非表示・WEBP デコードエラー修正）

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -127,7 +127,7 @@ function LoginForm() {
           href={`${API_BASE}/users/auth/google_oauth2`}
           className="w-full flex items-center justify-center gap-3 border border-gray-300 bg-white hover:bg-gray-50 text-gray-700 font-semibold py-2.5 rounded-full shadow-sm transition active:scale-[0.98]"
         >
-          <Image src="/images/google_icon4.png" alt="Google" width={28} height={28} />
+          <Image src="/images/google_icon4.png" alt="Google" width={28} height={28} unoptimized />
           <span>Googleでログイン</span>
         </a>
 
@@ -136,7 +136,7 @@ function LoginForm() {
           href={`${API_BASE}/users/auth/line`}
           className="mt-3 w-full flex items-center justify-center gap-3 bg-[#06C755] hover:bg-[#05b34c] text-white font-semibold py-2.5 rounded-full shadow-sm transition active:scale-[0.98]"
         >
-          <Image src="/images/line_logo.png" alt="LINE" width={32} height={32} />
+          <Image src="/images/line_logo.png" alt="LINE" width={32} height={32} unoptimized />
           <span>LINEでログイン</span>
         </a>
 
@@ -145,7 +145,7 @@ function LoginForm() {
           href={`${API_BASE}/users/auth/apple`}
           className="mt-3 w-full flex items-center justify-center gap-3 bg-black hover:bg-gray-900 text-white font-semibold py-2.5 rounded-full shadow-sm transition active:scale-[0.98]"
         >
-          <Image src="/images/apple_logo.png" alt="Apple" width={20} height={20} />
+          <Image src="/images/apple_logo.png" alt="Apple" width={20} height={20} unoptimized />
           <span>Appleでログイン</span>
         </a>
 


### PR DESCRIPTION
## 概要

iOS WebView（okaimonote-ios）に関する2つの問題を修正します。

## 変更内容

- **BottomNav の二重表示を修正**  
  iOS WebView はネイティブの CustomTabBar を持つため、WebView 内に Next.js の BottomNav が二重に描画されていた。User-Agent に `okaimonote-ios` が含まれる場合は BottomNav を非表示にし、不要な `/api/v1/me` の呼び出しも抑制する。

- **ログイン画面の WEBP デコードエラーを修正**  
  Google・LINE・Apple のログインボタンアイコンで `makeImagePlus WEBP err=-50` が発生していた。Next.js Image の WEBP 最適化（`unoptimized` 追加）を無効にして元の PNG を配信するよう変更する。

## テスト方法

- [ ] iOS シミュレーターでログイン画面を表示し、3つのアイコンが正常に表示されること
- [ ] iOS シミュレーターでナビゲーション時に Next.js の BottomNav が表示されないこと（ネイティブタブバーのみ表示）
- [ ] ブラウザ（PC/Android）では BottomNav が引き続き表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)