### PR TITLE
fix: iOS Safari オートフィル時にログインできない問題を修正

### DIFF
--- a/frontend/src/app/forgot-password/page.tsx
+++ b/frontend/src/app/forgot-password/page.tsx
@@ -10,13 +10,17 @@ export default function ForgotPasswordPage() {
   const [done, setDone] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  async function handleSubmit(e: FormEvent) {
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setIsSubmitting(true);
+    // iOS Safariのオートフィルは onChange を発火しないため、
+    // FormData でフォーム要素から直接値を読み取る
+    const formData = new FormData(e.currentTarget);
+    const emailValue = (formData.get("email") as string) || email;
     try {
       await apiFetch("/api/v1/passwords", {
         method: "POST",
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email: emailValue }),
       });
     } finally {
       // メールが存在しない場合も同じ画面を表示してメール存在確認を防ぐ
@@ -64,6 +68,7 @@ export default function ForgotPasswordPage() {
             </label>
             <input
               type="email"
+              name="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -20,14 +20,19 @@ function LoginForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   /** メール/パスワードでログイン */
-  const handleSubmit = async (e: FormEvent) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError("");
     setIsSubmitting(true);
+    // iOS Safariのオートフィルは onChange を発火しないため、
+    // FormData でフォーム要素から直接値を読み取る
+    const formData = new FormData(e.currentTarget);
+    const emailValue = (formData.get("email") as string) || email;
+    const passwordValue = (formData.get("password") as string) || password;
     try {
       await apiFetch("/api/v1/sessions", {
         method: "POST",
-        body: JSON.stringify({ email, password, remember_me: rememberMe ? "1" : "0" }),
+        body: JSON.stringify({ email: emailValue, password: passwordValue, remember_me: rememberMe ? "1" : "0" }),
       });
       router.push("/home");
     } catch {
@@ -64,6 +69,7 @@ function LoginForm() {
             </label>
             <input
               type="email"
+              name="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
@@ -78,6 +84,7 @@ function LoginForm() {
             </label>
             <input
               type="password"
+              name="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -15,15 +15,23 @@ export default function SignupPage() {
   const [done, setDone] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  async function handleSubmit(e: FormEvent) {
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setErrors([]);
     setIsSubmitting(true);
 
+    // iOS Safariのオートフィルは onChange を発火しないため、
+    // FormData でフォーム要素から直接値を読み取る
+    const formData = new FormData(e.currentTarget);
+    const nicknameValue = (formData.get("nickname") as string) || nickname;
+    const emailValue = (formData.get("email") as string) || email;
+    const passwordValue = (formData.get("password") as string) || password;
+    const passwordConfirmationValue = (formData.get("password_confirmation") as string) || passwordConfirmation;
+
     try {
       await apiFetch("/api/v1/registrations", {
         method: "POST",
-        body: JSON.stringify({ nickname, email, password, password_confirmation: passwordConfirmation }),
+        body: JSON.stringify({ nickname: nicknameValue, email: emailValue, password: passwordValue, password_confirmation: passwordConfirmationValue }),
       });
       setDone(true);
     } catch (err: unknown) {
@@ -89,6 +97,7 @@ export default function SignupPage() {
             </label>
             <input
               type="text"
+              name="nickname"
               value={nickname}
               onChange={(e) => setNickname(e.target.value)}
               required
@@ -104,6 +113,7 @@ export default function SignupPage() {
             </label>
             <input
               type="email"
+              name="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
@@ -119,6 +129,7 @@ export default function SignupPage() {
             </label>
             <input
               type="password"
+              name="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
@@ -134,6 +145,7 @@ export default function SignupPage() {
             </label>
             <input
               type="password"
+              name="password_confirmation"
               value={passwordConfirmation}
               onChange={(e) => setPasswordConfirmation(e.target.value)}
               required

--- a/frontend/tests/hooks/useCategories.test.ts
+++ b/frontend/tests/hooks/useCategories.test.ts
@@ -20,6 +20,7 @@ describe("useCategories", () => {
       data: mockCategories,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: vi.fn(),
     } as ReturnType<typeof useSWR>);
 
@@ -37,6 +38,7 @@ describe("useCategories", () => {
       data: mockCategories,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate,
     } as ReturnType<typeof useSWR>);
 

--- a/frontend/tests/hooks/useFamily.test.ts
+++ b/frontend/tests/hooks/useFamily.test.ts
@@ -26,6 +26,7 @@ describe("useFamily", () => {
       data: mockFamily,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: vi.fn(),
     } as ReturnType<typeof useSWR>);
 
@@ -41,6 +42,7 @@ describe("useFamily", () => {
       data: undefined,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: mutateMock,
     } as ReturnType<typeof useSWR>);
 
@@ -66,6 +68,7 @@ describe("useFamily", () => {
       data: { id: 1, name: "旧名前" },
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: mutateMock,
     } as ReturnType<typeof useSWR>);
 
@@ -91,6 +94,7 @@ describe("useFamily", () => {
       data: { id: 1, invite_token: "old_token" },
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: mutateMock,
     } as ReturnType<typeof useSWR>);
 

--- a/frontend/tests/hooks/useHome.test.ts
+++ b/frontend/tests/hooks/useHome.test.ts
@@ -29,6 +29,7 @@ describe("useHome", () => {
       data: { price_records: mockRecords },
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: vi.fn(),
     } as ReturnType<typeof useSWR>);
 
@@ -46,6 +47,7 @@ describe("useHome", () => {
       data: { price_records: [] },
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: vi.fn(),
     } as ReturnType<typeof useSWR>);
 

--- a/frontend/tests/hooks/usePriceRecordForm.test.ts
+++ b/frontend/tests/hooks/usePriceRecordForm.test.ts
@@ -22,6 +22,7 @@ describe("usePriceRecordForm", () => {
       data: mockFormData,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: vi.fn(),
     } as ReturnType<typeof useSWR>);
 
@@ -40,6 +41,7 @@ describe("usePriceRecordForm", () => {
       data: mockFormData,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: vi.fn(),
     } as ReturnType<typeof useSWR>);
 

--- a/frontend/tests/hooks/useProducts.test.ts
+++ b/frontend/tests/hooks/useProducts.test.ts
@@ -31,6 +31,7 @@ describe("useProducts", () => {
       data: mockResponse,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: vi.fn(),
     } as ReturnType<typeof useSWR>);
 
@@ -47,6 +48,7 @@ describe("useProducts", () => {
       data: mockResponse,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: vi.fn(),
     } as ReturnType<typeof useSWR>);
 
@@ -63,6 +65,7 @@ describe("useProducts", () => {
       data: undefined,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: vi.fn(),
     } as ReturnType<typeof useSWR>);
 
@@ -76,6 +79,7 @@ describe("useProducts", () => {
       data: undefined,
       error: undefined,
       isLoading: true,
+      isValidating: false,
       mutate: vi.fn(),
     } as ReturnType<typeof useSWR>);
 
@@ -89,6 +93,7 @@ describe("useProducts", () => {
       data: mockResponse,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: vi.fn(),
     } as ReturnType<typeof useSWR>);
 
@@ -104,6 +109,7 @@ describe("useProducts", () => {
       data: mockResponse,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: vi.fn(),
     } as ReturnType<typeof useSWR>);
 

--- a/frontend/tests/hooks/useProfile.test.ts
+++ b/frontend/tests/hooks/useProfile.test.ts
@@ -16,6 +16,7 @@ describe("useProfile", () => {
       data: { id: 1, nickname: "元の名前", prefecture: "東京都" },
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: vi.fn(),
     } as ReturnType<typeof useSWR>);
 

--- a/frontend/tests/hooks/useShoppingList.test.ts
+++ b/frontend/tests/hooks/useShoppingList.test.ts
@@ -27,6 +27,7 @@ describe("useShoppingList", () => {
       data: mockList,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: vi.fn(),
     } as ReturnType<typeof useSWR>);
 
@@ -45,6 +46,7 @@ describe("useShoppingList", () => {
       data: mockList,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate,
     } as ReturnType<typeof useSWR>);
 
@@ -76,6 +78,7 @@ describe("useShoppingList", () => {
       data: mockList,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate,
     } as ReturnType<typeof useSWR>);
 
@@ -107,6 +110,7 @@ describe("useShoppingList", () => {
       data: mockList,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate,
     } as ReturnType<typeof useSWR>);
 
@@ -132,6 +136,7 @@ describe("useShoppingList", () => {
       data: mockList,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate,
     } as ReturnType<typeof useSWR>);
 

--- a/frontend/tests/hooks/useShops.test.ts
+++ b/frontend/tests/hooks/useShops.test.ts
@@ -21,6 +21,7 @@ describe("useShops", () => {
       data: mockShops,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: vi.fn(),
     } as ReturnType<typeof useSWR>);
 
@@ -37,6 +38,7 @@ describe("useShops", () => {
       data: undefined,
       error: undefined,
       isLoading: true,
+      isValidating: false,
       mutate: vi.fn(),
     } as ReturnType<typeof useSWR>);
 
@@ -50,6 +52,7 @@ describe("useShops", () => {
       data: undefined,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate: vi.fn(),
     } as ReturnType<typeof useSWR>);
 
@@ -64,6 +67,7 @@ describe("useShops", () => {
       data: mockShops,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate,
     } as ReturnType<typeof useSWR>);
 
@@ -90,6 +94,7 @@ describe("useShops", () => {
       data: mockShops,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate,
     } as ReturnType<typeof useSWR>);
 
@@ -116,6 +121,7 @@ describe("useShops", () => {
       data: mockShops,
       error: undefined,
       isLoading: false,
+      isValidating: false,
       mutate,
     } as ReturnType<typeof useSWR>);
 


### PR DESCRIPTION
## 概要

iPhoneでパスワードを保存・オートフィルした際にログインできない問題を修正します。

## 原因

iOS Safariのオートフィル機能はネイティブDOMの値を直接書き換えますが、**Reactの`onChange`イベントを発火しません**。そのため、`email`・`password`のReact stateが空文字`""`のままAPIに送信され、認証失敗していました。

同じ問題がログイン・新規登録・パスワードリセットの3画面すべてに存在していました。

## 修正内容

### iOS autofill対応（バグ修正）

- `login/page.tsx` / `signup/page.tsx` / `forgot-password/page.tsx` の全フォーム
  - `<input>` に `name` 属性を追加
  - `handleSubmit` 内で `FormData(e.currentTarget)` を使ってDOM要素から直接値を読み取るよう変更
  - React stateはフォールバックとして維持（通常入力は従来通り動作）

### テストファイルのTypeScriptエラー修正

- SWRのモックオブジェクトに必須プロパティ `isValidating: false` が未設定だったため、全hooksテストファイル（8件）に追加

## テスト

- 全35テスト パス
- TypeScriptエラー 0件

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `frontend/src/app/login/page.tsx` | FormData対応・name属性追加 |
| `frontend/src/app/signup/page.tsx` | FormData対応・name属性追加 |
| `frontend/src/app/forgot-password/page.tsx` | FormData対応・name属性追加 |
| `tests/hooks/*.test.ts`（8件） | SWRモックに`isValidating`追加 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)