### PR TITLE
improve: ログイン維持をデフォルトON・保持期間を6ヶ月に変更

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -190,7 +190,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  config.remember_for = 90.days
+  config.remember_for = 6.months
 
   # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -15,7 +15,7 @@ function LoginForm() {
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [rememberMe, setRememberMe] = useState(false);
+  const [rememberMe, setRememberMe] = useState(true);
   const [error, setError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 


### PR DESCRIPTION
## 概要

節約アプリとして毎回ログインを求めるのは摩擦が大きいため、ログイン維持をデフォルトONにし、保持期間を6ヶ月に延長します。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `config/initializers/devise.rb` | `remember_for` を 90日 → 6ヶ月 に変更 |
| `frontend/src/app/login/page.tsx` | `rememberMe` の初期値を `false` → `true` に変更 |

## 動作

- ログイン画面で「ログインを維持する」チェックボックスが最初からONになる
- ログイン後、6ヶ月間はパスワード再入力不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)