### PR TITLE
【バグ修正】remember_meをDevise正式方式に修正（attributeのセット）

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -12,9 +12,11 @@ module Api
       def create
         user = User.find_by(email: params[:email])
         if user&.valid_password?(params[:password])
-          # sign_in より前に remember_me! を呼ぶ必要がある。
-          # sign_in 実行時に remember_token が設定済みでないと永続 Cookie がレスポンスに含まれない。
-          user.remember_me! if params[:remember_me] == "1"
+          # sign_in より前に remember_me attribute をセットする必要がある。
+          # Devise の after_set_user フックは record.remember_me attribute が truthy の場合に
+          # remember_me! を呼び出して永続 Cookie を発行する。
+          # remember_me! メソッドを直接呼んでも attribute がセットされないため Cookie は発行されない。
+          user.remember_me = "1" if params[:remember_me] == "1"
           sign_in(user)
           render json: {
             id: user.id,

--- a/app/controllers/ios_auth_controller.rb
+++ b/app/controllers/ios_auth_controller.rb
@@ -15,10 +15,12 @@ class IosAuthController < ApplicationController
       return redirect_to new_user_session_path, alert: "このアカウントは停止されています。"
     end
 
-    # remember_me を有効化してから sign_in することで、有効期限付き Cookie が発行される。
+    # sign_in より前に remember_me attribute をセットする必要がある。
+    # Devise の after_set_user フックは record.remember_me attribute が truthy の場合に
+    # remember_me! を呼び出して永続 Cookie を発行する。
     # WKWebView はセッション Cookie（有効期限なし）をディスクに保存しないため、
-    # フォースクイット後にログアウトしてしまう問題を防ぐ。
-    user.remember_me!
+    # iOS では常に永続 Cookie を発行してフォースクイット後もログイン維持する。
+    user.remember_me = true
     sign_in(user)
 
     # Cookie はレスポンスヘッダに自動で含まれる


### PR DESCRIPTION
## Summary

PR #258 にマージされた修正は `remember_me!` メソッドを呼ぶ実装だったが、実際には Cookie が発行されていなかった。

Devise の `after_set_user` フックは `record.remember_me` **attribute** が truthy の場合のみ永続 Cookie を発行する仕様。`remember_me!` メソッドは DB にトークンを保存するだけでこの attribute をセットしない。

```ruby
# 修正前（PR #258 の実装、Cookie 未発行）
user.remember_me!  # DB保存のみ、attribute は nil のまま
sign_in(user)      # Devise: user.remember_me → nil → Cookie 発行されない

# 修正後（正しい実装）
user.remember_me = "1"  # attribute をセット
sign_in(user)           # Devise: user.remember_me → "1" → Cookie 発行される
```

## Test plan

- [ ] メールログイン＋「ログインを維持する」ON → アプリをスワイプで閉じ → 再起動してもログイン維持される
- [ ] Googleログイン → アプリをスワイプで閉じ → 再起動してもログイン維持される
- [ ] RSpec テストがすべてパスする

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)