### PR TITLE
【iOS不具合修正】タップ反応なし・オートズームを修正

### DIFF
--- a/frontend/src/app/home/page.tsx
+++ b/frontend/src/app/home/page.tsx
@@ -81,8 +81,9 @@ function PriceRecordCard({
   onSelect: (id: number) => void;
 }) {
   return (
-    <div
-      className="bg-white border border-orange-100 shadow-sm hover:shadow-md transition rounded-2xl p-5 cursor-pointer"
+    <button
+      type="button"
+      className="w-full text-left bg-white border border-orange-100 shadow-sm hover:shadow-md transition rounded-2xl p-5"
       onClick={() => onSelect(record.product_id)}
     >
       <div className="flex justify-between items-start mb-2 gap-3">
@@ -101,7 +102,7 @@ function PriceRecordCard({
           {record.memo}
         </p>
       )}
-    </div>
+    </button>
   );
 }
 
@@ -168,7 +169,7 @@ function SearchFilterPanel({
               value={productName}
               onChange={(e) => setProductName(e.target.value)}
               placeholder="例：牛乳"
-              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 text-sm outline-none transition placeholder-gray-400"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 text-base outline-none transition placeholder-gray-400"
             />
           </div>
 
@@ -180,7 +181,7 @@ function SearchFilterPanel({
             <select
               value={categoryId}
               onChange={(e) => setCategoryId(e.target.value)}
-              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 text-sm outline-none transition bg-white"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 text-base outline-none transition bg-white"
             >
               <option value="">すべて</option>
               {formData?.categories.map((c) => (
@@ -199,7 +200,7 @@ function SearchFilterPanel({
             <select
               value={shopId}
               onChange={(e) => setShopId(e.target.value)}
-              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 text-sm outline-none transition bg-white"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 text-base outline-none transition bg-white"
             >
               <option value="">すべて</option>
               {formData?.shops.map((s) => (

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -75,7 +75,7 @@ function LoginForm() {
               required
               autoComplete="email"
               placeholder="example@email.com"
-              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 outline-none transition placeholder-gray-400"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 text-base outline-none transition placeholder-gray-400"
             />
           </div>
           <div>
@@ -90,7 +90,7 @@ function LoginForm() {
               required
               autoComplete="current-password"
               placeholder="••••••"
-              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 outline-none transition"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 text-base outline-none transition"
             />
           </div>
 

--- a/frontend/src/app/price_records/new/page.tsx
+++ b/frontend/src/app/price_records/new/page.tsx
@@ -107,7 +107,7 @@ export default function NewPriceRecordPage() {
               }}
               placeholder="例：牛乳"
               list="product-list"
-              className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
+              className="w-full border border-gray-300 rounded-xl p-3 text-base focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
             />
             <datalist id="product-list">
               {formData?.products.map((p) => (
@@ -127,7 +127,7 @@ export default function NewPriceRecordPage() {
                 onChange={(e) =>
                   setCategoryId(e.target.value ? Number(e.target.value) : null)
                 }
-                className="w-full border border-gray-300 rounded-xl p-3 bg-white focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
+                className="w-full border border-gray-300 rounded-xl p-3 text-base bg-white focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
               >
                 <option value="">選択してください</option>
                 {formData?.categories.map((c) => (
@@ -149,7 +149,7 @@ export default function NewPriceRecordPage() {
               onChange={(e) =>
                 setShopId(e.target.value ? Number(e.target.value) : null)
               }
-              className="w-full border border-gray-300 rounded-xl p-3 bg-white focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
+              className="w-full border border-gray-300 rounded-xl p-3 text-base bg-white focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
             >
               <option value="">選択してください</option>
               {formData?.shops.map((s) => (
@@ -172,7 +172,7 @@ export default function NewPriceRecordPage() {
               min={1}
               step={1}
               placeholder="例：198"
-              className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
+              className="w-full border border-gray-300 rounded-xl p-3 text-base focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
             />
           </div>
 
@@ -185,7 +185,7 @@ export default function NewPriceRecordPage() {
               type="date"
               value={purchasedAt}
               onChange={(e) => setPurchasedAt(e.target.value)}
-              className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
+              className="w-full border border-gray-300 rounded-xl p-3 text-base focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
             />
           </div>
 
@@ -199,7 +199,7 @@ export default function NewPriceRecordPage() {
               onChange={(e) => setMemo(e.target.value)}
               rows={3}
               placeholder="例：広告の品、まとめ買いなど"
-              className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
+              className="w-full border border-gray-300 rounded-xl p-3 text-base focus:ring-2 focus:ring-orange-400 outline-none shadow-sm"
             />
           </div>
 

--- a/frontend/src/app/shopping_list/page.tsx
+++ b/frontend/src/app/shopping_list/page.tsx
@@ -79,14 +79,14 @@ export default function ShoppingListPage() {
             value={name}
             onChange={setName}
             placeholder="商品名を入力（例：にんじん）"
-            className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-orange-400 focus:outline-none shadow-sm transition"
+            className="w-full border border-gray-300 rounded-xl p-3 text-base focus:ring-2 focus:ring-orange-400 focus:outline-none shadow-sm transition"
           />
           <textarea
             value={memo}
             onChange={(e) => setMemo(e.target.value)}
             rows={2}
             placeholder="メモ（例：広告の品）"
-            className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-orange-400 focus:outline-none shadow-sm transition"
+            className="w-full border border-gray-300 rounded-xl p-3 text-base focus:ring-2 focus:ring-orange-400 focus:outline-none shadow-sm transition"
           />
           <button
             type="submit"

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -103,7 +103,7 @@ export default function SignupPage() {
               required
               maxLength={20}
               placeholder="おかいも太郎"
-              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 outline-none transition"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 text-base outline-none transition"
             />
           </div>
 
@@ -119,7 +119,7 @@ export default function SignupPage() {
               required
               autoComplete="email"
               placeholder="example@email.com"
-              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 outline-none transition"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 text-base outline-none transition"
             />
           </div>
 
@@ -135,7 +135,7 @@ export default function SignupPage() {
               required
               autoComplete="new-password"
               placeholder="8文字以上"
-              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 outline-none transition"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 text-base outline-none transition"
             />
           </div>
 
@@ -151,7 +151,7 @@ export default function SignupPage() {
               required
               autoComplete="new-password"
               placeholder="もう一度入力してください"
-              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 outline-none transition"
+              className="w-full rounded-xl border border-gray-300 focus:ring-2 focus:ring-orange-400 focus:border-orange-400 px-3 py-2 text-base outline-none transition"
             />
           </div>
 

--- a/frontend/src/components/shopping/AutocompleteInput.tsx
+++ b/frontend/src/components/shopping/AutocompleteInput.tsx
@@ -70,15 +70,15 @@ export function AutocompleteInput({ value, onChange, placeholder, className }: P
     }
   };
 
-  // コンテナ外クリックで候補を閉じる
+  // コンテナ外タップ・クリックで候補を閉じる（iOS対応で pointerdown を使用）
   useEffect(() => {
-    const handleOutside = (e: MouseEvent) => {
+    const handleOutside = (e: PointerEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setIsOpen(false);
       }
     };
-    document.addEventListener("mousedown", handleOutside);
-    return () => document.removeEventListener("mousedown", handleOutside);
+    document.addEventListener("pointerdown", handleOutside);
+    return () => document.removeEventListener("pointerdown", handleOutside);
   }, []);
 
   return (
@@ -97,8 +97,8 @@ export function AutocompleteInput({ value, onChange, placeholder, className }: P
           {candidates.map((name, i) => (
             <li
               key={name}
-              onMouseDown={() => handleSelect(name)}
-              className={`px-4 py-2.5 text-sm cursor-pointer transition ${
+              onClick={() => handleSelect(name)}
+              className={`px-4 py-3 text-sm cursor-pointer transition ${
                 i === activeIndex
                   ? "bg-orange-100 text-orange-700 font-semibold"
                   : "hover:bg-orange-50 text-gray-700"


### PR DESCRIPTION
## 概要

iOS実機WebViewで発生していた3つの不具合をまとめて修正します。

## 変更内容

- **#262** `AutocompleteInput` のオートコンプリート候補がタップで選択できない
  - 候補リストの `onMouseDown` → `onClick` に変更
  - 候補リスト外クリック検知を `mousedown` → `pointerdown` に変更（iOS対応）
- **#263** `input` / `select` / `textarea` の文字サイズが16px未満でiOSのオートズームが発動
  - 該当フィールドに `text-base`（16px）を追加
  - 対象: `login`, `signup`, `home`（検索フィルター）, `shopping_list`, `price_records/new`
- **#264** `PriceRecordCard`（ホーム画面の価格履歴）が `<div onClick>` で実装されておりiOSでタップ不可
  - `<button type="button">` に変更

## 対象ファイル

- `frontend/src/components/shopping/AutocompleteInput.tsx` — #262
- `frontend/src/app/home/page.tsx` — #263, #264
- `frontend/src/app/login/page.tsx` — #263
- `frontend/src/app/signup/page.tsx` — #263
- `frontend/src/app/price_records/new/page.tsx` — #263
- `frontend/src/app/shopping_list/page.tsx` — #263

## 受入テスト項目

- [ ] オートコンプリート候補をiOS実機でタップして選択できる
- [ ] ログイン画面でメールアドレス/パスワード入力時にオートズームしない
- [ ] 価格登録画面の各入力欄でオートズームしない
- [ ] ホーム画面の検索フィルターの入力欄/セレクトでオートズームしない
- [ ] ホーム画面の価格履歴カードをタップしてサマリーが更新される

Closes #262
Closes #263
Closes #264