### PR TITLE
【iOS対応】window.confirm をカスタム確認モーダルに置き換え

### DIFF
--- a/frontend/src/app/admin/families/[id]/page.tsx
+++ b/frontend/src/app/admin/families/[id]/page.tsx
@@ -4,6 +4,7 @@ import { use } from "react";
 import useSWR from "swr";
 import Link from "next/link";
 import { apiFetch } from "@/lib/api";
+import { useConfirm } from "@/hooks/useConfirm";
 import type { AdminFamily } from "@/types";
 
 export default function AdminFamilyDetailPage({ params }: { params: Promise<{ id: string }> }) {
@@ -12,12 +13,13 @@ export default function AdminFamilyDetailPage({ params }: { params: Promise<{ id
     `/api/v1/admin/families/${id}`,
     (path: string) => apiFetch<AdminFamily>(path)
   );
+  const { confirm, ConfirmModalElement } = useConfirm();
 
   if (isLoading || !family) return <p className="text-gray-500">読み込み中...</p>;
 
   async function handleChangeAdmin(userId: number) {
     const target = family!.members?.find((m) => m.id === userId);
-    if (!confirm(`${target?.nickname ?? "このユーザー"} を管理者にしますか？`)) return;
+    if (!await confirm({ message: `${target?.nickname ?? "このユーザー"} を管理者にしますか？`, confirmLabel: "変更する" })) return;
     await apiFetch(`/api/v1/admin/families/${id}/change_admin`, {
       method: "PATCH",
       body: JSON.stringify({ user_id: userId }),
@@ -27,12 +29,14 @@ export default function AdminFamilyDetailPage({ params }: { params: Promise<{ id
 
   async function handleRemoveMember(userId: number) {
     const target = family!.members?.find((m) => m.id === userId);
-    if (!confirm(`${target?.nickname ?? "このユーザー"} を除名しますか？`)) return;
+    if (!await confirm({ message: `${target?.nickname ?? "このユーザー"} を除名しますか？`, confirmLabel: "除名する", variant: "danger" })) return;
     await apiFetch(`/api/v1/admin/families/${id}/members/${userId}`, { method: "DELETE" });
     mutate();
   }
 
   return (
+    <>
+    {ConfirmModalElement}
     <div className="space-y-4 max-w-2xl">
       <div className="flex items-center gap-3">
         <Link href="/admin/families" className="text-gray-400 hover:text-gray-600 text-sm">← 一覧</Link>
@@ -83,5 +87,6 @@ export default function AdminFamilyDetailPage({ params }: { params: Promise<{ id
         </table>
       </div>
     </div>
+    </>
   );
 }

--- a/frontend/src/app/admin/users/[id]/page.tsx
+++ b/frontend/src/app/admin/users/[id]/page.tsx
@@ -4,6 +4,7 @@ import { use, useState } from "react";
 import useSWR from "swr";
 import Link from "next/link";
 import { apiFetch } from "@/lib/api";
+import { useConfirm } from "@/hooks/useConfirm";
 import type { AdminUser } from "@/types";
 
 export default function AdminUserDetailPage({ params }: { params: Promise<{ id: string }> }) {
@@ -13,6 +14,7 @@ export default function AdminUserDetailPage({ params }: { params: Promise<{ id: 
     (path: string) => apiFetch<AdminUser>(path)
   );
 
+  const { confirm, ConfirmModalElement } = useConfirm();
   const [memo, setMemo] = useState("");
   const [editingMemo, setEditingMemo] = useState(false);
   const [banReason, setBanReason] = useState("");
@@ -42,13 +44,15 @@ export default function AdminUserDetailPage({ params }: { params: Promise<{ id: 
   }
 
   async function handleUnban() {
-    if (!confirm("BANを解除しますか？")) return;
+    if (!await confirm({ message: "BANを解除しますか？", confirmLabel: "解除する" })) return;
     await apiFetch(`/api/v1/admin/users/${id}/unban`, { method: "PATCH" });
     mutate();
     setMessage("BAN解除しました");
   }
 
   return (
+    <>
+    {ConfirmModalElement}
     <div className="space-y-4 max-w-3xl">
       <div className="flex items-center gap-3">
         <Link href="/admin/users" className="text-gray-400 hover:text-gray-600 text-sm">← 一覧</Link>
@@ -143,6 +147,7 @@ export default function AdminUserDetailPage({ params }: { params: Promise<{ id: 
         </div>
       )}
     </div>
+    </>
   );
 }
 

--- a/frontend/src/app/family/page.tsx
+++ b/frontend/src/app/family/page.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { useAuth } from "@/hooks/useAuth";
 import { useFamily } from "@/hooks/useFamily";
 import { useFlash } from "@/contexts/FlashContext";
+import { useConfirm } from "@/hooks/useConfirm";
 
 // QRコードは大きいので dynamic import で遅延読み込み
 const QRCodeSVG = dynamic(
@@ -22,6 +23,7 @@ export default function FamilyPage() {
   const { family, isLoading, destroyFamily, leaveFamily, transferOwner, regenerateInvite } =
     useFamily();
   const { flash } = useFlash();
+  const { confirm, ConfirmModalElement } = useConfirm();
 
   const [transferTargetId, setTransferTargetId] = useState<number | null>(null);
   const [showInviteUrl, setShowInviteUrl] = useState(false);
@@ -78,7 +80,6 @@ export default function FamilyPage() {
 
   async function handleTransfer() {
     if (!transferTargetId) return;
-    if (!confirm("管理者権限を譲渡しますか？")) return;
     try {
       await transferOwner(transferTargetId);
       flash("notice", "管理者権限を譲渡しました");
@@ -89,7 +90,7 @@ export default function FamilyPage() {
   }
 
   async function handleLeave() {
-    if (!confirm("ファミリーから脱退しますか？")) return;
+    if (!await confirm({ message: "ファミリーから脱退しますか？", confirmLabel: "脱退する", variant: "danger" })) return;
     try {
       await leaveFamily();
       flash("notice", "ファミリーから脱退しました");
@@ -100,7 +101,7 @@ export default function FamilyPage() {
   }
 
   async function handleDestroy() {
-    if (!confirm("ファミリーを解散しますか？この操作は取り消せません。")) return;
+    if (!await confirm({ message: "ファミリーを解散しますか？この操作は取り消せません。", confirmLabel: "解散する", variant: "danger" })) return;
     try {
       await destroyFamily();
       flash("notice", "ファミリーを解散しました");
@@ -111,6 +112,8 @@ export default function FamilyPage() {
   }
 
   return (
+    <>
+    {ConfirmModalElement}
     <div className="min-h-screen bg-orange-50 py-10 pb-24 px-4">
       <div className="max-w-md mx-auto space-y-4">
         <h1 className="text-2xl font-bold text-center text-orange-500 mb-2">
@@ -282,5 +285,6 @@ export default function FamilyPage() {
         </Link>
       </div>
     </div>
+    </>
   );
 }

--- a/frontend/src/app/shopping_list/page.tsx
+++ b/frontend/src/app/shopping_list/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useShoppingList } from "@/hooks/useShoppingList";
 import { useFlash } from "@/contexts/FlashContext";
+import { useConfirm } from "@/hooks/useConfirm";
 import { ShoppingItemRow } from "@/components/shopping/ShoppingItemRow";
 import { AutocompleteInput } from "@/components/shopping/AutocompleteInput";
 
@@ -10,6 +11,7 @@ export default function ShoppingListPage() {
   const { list, isLoading, addItem, togglePurchased, deleteItem, deletePurchased } =
     useShoppingList();
   const { flash } = useFlash();
+  const { confirm, ConfirmModalElement } = useConfirm();
   const [name, setName] = useState("");
   const [memo, setMemo] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -46,7 +48,7 @@ export default function ShoppingListPage() {
   }
 
   async function handleDeletePurchased() {
-    if (!window.confirm("購入済みの商品をすべて削除しますか？")) return;
+    if (!await confirm({ message: "購入済みの商品をすべて削除しますか？", confirmLabel: "削除する", variant: "danger" })) return;
     try {
       await deletePurchased();
     } catch {
@@ -66,6 +68,8 @@ export default function ShoppingListPage() {
   const purchased = list?.items.filter((i) => i.purchased) ?? [];
 
   return (
+    <>
+    {ConfirmModalElement}
     <div className="min-h-screen bg-orange-50 py-2 pb-24 px-4 sm:px-6 md:px-8">
       <div className="w-full max-w-md sm:max-w-lg md:max-w-xl mx-auto bg-white rounded-2xl shadow p-6 md:p-8 border border-orange-100">
         {/* タイトル */}
@@ -146,5 +150,6 @@ export default function ShoppingListPage() {
         </div>
       </div>
     </div>
+    </>
   );
 }

--- a/frontend/src/components/ui/ConfirmModal.tsx
+++ b/frontend/src/components/ui/ConfirmModal.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+interface Props {
+  message: string;
+  confirmLabel?: string;
+  /** "danger": 赤ボタン / "default": オレンジボタン */
+  variant?: "default" | "danger";
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/** iOS WKWebView で window.confirm が使えないため、カスタム確認モーダル */
+export function ConfirmModal({
+  message,
+  confirmLabel = "実行する",
+  variant = "default",
+  onConfirm,
+  onCancel,
+}: Props) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
+      {/* オーバーレイ（タップでキャンセル） */}
+      <div className="absolute inset-0 bg-black/40" onClick={onCancel} />
+
+      {/* モーダルカード */}
+      <div className="relative w-full max-w-sm bg-white rounded-2xl shadow-xl border border-orange-100 p-6 z-10">
+        <p className="text-base text-gray-700 text-center leading-relaxed mb-7">
+          {message}
+        </p>
+        <div className="flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={`w-full py-3 rounded-xl font-semibold text-white transition ${
+              variant === "danger"
+                ? "bg-red-500 hover:bg-red-600 active:bg-red-700"
+                : "bg-orange-500 hover:bg-orange-600 active:bg-orange-700"
+            }`}
+          >
+            {confirmLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="w-full py-3 rounded-xl font-semibold text-gray-600 bg-gray-100 hover:bg-gray-200 active:bg-gray-300 transition"
+          >
+            キャンセル
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useConfirm.tsx
+++ b/frontend/src/hooks/useConfirm.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { ConfirmModal } from "@/components/ui/ConfirmModal";
+
+interface ConfirmOptions {
+  message: string;
+  confirmLabel?: string;
+  variant?: "default" | "danger";
+}
+
+interface ConfirmState {
+  message: string;
+  confirmLabel: string;
+  variant: "default" | "danger";
+  resolve: (value: boolean) => void;
+}
+
+/**
+ * Promise ベースの確認モーダルフック。
+ * iOS WKWebView では window.confirm が動作しないため、カスタムモーダルで代替する。
+ *
+ * 使い方:
+ *   const { confirm, ConfirmModalElement } = useConfirm();
+ *   if (!await confirm("削除しますか？")) return;
+ *   // JSX に {ConfirmModalElement} を含めること
+ */
+export function useConfirm() {
+  const [state, setState] = useState<ConfirmState | null>(null);
+
+  const confirm = useCallback(
+    (options: string | ConfirmOptions): Promise<boolean> => {
+      return new Promise((resolve) => {
+        const opts = typeof options === "string" ? { message: options } : options;
+        setState({
+          message: opts.message,
+          confirmLabel: opts.confirmLabel ?? "実行する",
+          variant: opts.variant ?? "default",
+          resolve,
+        });
+      });
+    },
+    []
+  );
+
+  const handleConfirm = useCallback(() => {
+    setState((prev) => {
+      prev?.resolve(true);
+      return null;
+    });
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    setState((prev) => {
+      prev?.resolve(false);
+      return null;
+    });
+  }, []);
+
+  const ConfirmModalElement = state ? (
+    <ConfirmModal
+      message={state.message}
+      confirmLabel={state.confirmLabel}
+      variant={state.variant}
+      onConfirm={handleConfirm}
+      onCancel={handleCancel}
+    />
+  ) : null;
+
+  return { confirm, ConfirmModalElement };
+}


### PR DESCRIPTION
## 概要

iOS WKWebView（Capacitor）では `window.confirm()` が常に `false` を返すため、iOS実機で確認が必要な操作（一括削除等）がすべて無効になっていた。
Promise ベースのカスタム確認モーダルを作成し、全7箇所の `confirm()` を置き換える。

## 変更内容

### 新規ファイル
- `components/ui/ConfirmModal.tsx` — オレンジ系テーマの確認モーダル UI、44px タッチターゲット確保
- `hooks/useConfirm.tsx` — `confirm()` が `Promise<boolean>` を返すフック

### 既存ファイル修正（全7箇所）

| ファイル | 操作 |
|---|---|
| `shopping_list/page.tsx` | 購入済み一括削除 |
| `family/page.tsx` | ファミリー脱退・解散 |
| `family/page.tsx` | 権限譲渡：インライン確認 UI が既存のため `confirm()` 削除のみ |
| `admin/users/[id]/page.tsx` | BAN解除 |
| `admin/families/[id]/page.tsx` | 管理者変更・除名 |

## 受入テスト項目

- [ ] iOS 実機で「購入済みを削除」を押すとモーダルが表示される
- [ ] モーダルの「削除する」で処理が実行される
- [ ] モーダルの「キャンセル」または背景タップで処理が中断される
- [ ] ファミリー脱退・解散でも同様に動作する
- [ ] PC ブラウザでも問題なく動作する
- [ ] モーダルデザインがオレンジ系テーマと一致している

Closes #266